### PR TITLE
[discuss] Mapbox vector tile (PBF) output

### DIFF
--- a/app/controllers/app.js
+++ b/app/controllers/app.js
@@ -467,7 +467,8 @@ function handleQuery(req, res) {
                   filename: filename,
                   bufferedRows: global.settings.bufferedRows,
                   callback: params.callback,
-                  abortChecker: checkAborted
+                  abortChecker: checkAborted,
+                  params: params
                 };
 
                 if ( req.profiler ) {

--- a/app/models/formats/pbf.js
+++ b/app/models/formats/pbf.js
@@ -1,0 +1,105 @@
+"use strict";
+
+var fs = require("fs"),
+    util = require("util"),
+    zlib = require("zlib");
+
+var async = require("async"),
+    mapnik = require("mapnik"),
+    PSQL = require("cartodb-psql"),
+    mercator = new (require("sphericalmercator"))();
+
+// TODO check that the relative path works (otherwise use __dirname)
+var XML_TEMPLATE = fs.readFileSync("../../../config/pbf_template.xml");
+
+// TODO mapnik-pool
+
+var PBF = function() {};
+
+PBF.prototype.getContentType = function() {
+  return "application/x-protobuf";
+};
+
+PBF.prototype.getFileExtension = function() {
+  return "pbf";
+};
+
+PBF.prototype.sendResponse = function(options, callback) {
+  var pg = new PSQL(options.dbopts),
+      z = options.params.z | 0,
+      x = options.params.x | 0,
+      y = options.params.y | 0;
+
+  console.log("SQL:", options.sql);
+
+  return async.waterfall([
+    function(done) {
+      // TODO might we have !bbox!-style tokens?
+      // alternately, CDB_...XY will be part of the query and z,x,y will be
+      // duplicated in the params
+      var query = util.format("SELECT * FROM (%s) AS _ LIMIT 0", options.sql);
+      return pg.query(query, done);
+    },
+    function(result, done) {
+      var cols = result.fields
+        .filter(function(x) {
+          return options.skipfields.indexOf(x.name) >= 0;
+        })
+        .map(function(x) {
+          return pg.quoteIdentifier(x.name);
+        });
+
+      var query = util.format("SELECT %s FROM (%s) AS _",
+                              cols.join(", "),
+                              options.sql);
+
+      return done(null, query);
+    },
+    function(query, done) {
+      // TODO use mapnik=pool
+      var map = new mapnik.Map(256, 256);
+
+      map.extent = mercator.bbox(x, y, z, false, "900913");
+
+      // TODO use handlebars instead
+      var xml = XML_TEMPLATE
+        .replace(/{{name}}/, options.filename)
+        .replace(/{{dbname}}/, options.dbopts.dbname)
+        .replace(/{{host}}/, options.dbopts.host)
+        .replace(/{{user}}/, options.dbopts.user)
+        .replace(/{{password}}/, options.dbopts.pass)
+        .replace(/{{port}}/, options.dbopts.port)
+        .replace(/{{geometry_field}}/, options.gn);
+
+      return map.fromString(xml, {
+        strict: true
+      }, done);
+    },
+    function(map, done) {
+      map.bufferSize = 256; // TODO make configurable (and prefer tile-specific opts)
+
+      var opts = {
+        buffer_size: map.bufferSize, // TODO make optional
+        tolerance: Math.max(0, Math.min(5, 14 - z))
+      };
+
+      return map.render(new mapnik.VectorTile(z, x, y), opts, done);
+    },
+    function(vtile, done) {
+      return zlib.gzip(vtile.getData(), done);
+    }
+  ], function(err, buffer) {
+    if (err) {
+      return callback(err);
+    }
+
+    // set the content encoding (we know sink is an HttpResponse)
+    options.sink.set("Content-Encoding", "gzip");
+
+    options.sink.send(buffer);
+
+    return callback();
+  });
+};
+
+module.exports = PBF;

--- a/config/pbf_template.xml
+++ b/config/pbf_template.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Map srs="+proj=merc +lon_0=0 +lat_ts=0 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs">
+
+  <Layer name="{{name}}" srs="+proj=merc +lon_0=0 +lat_ts=0 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs">
+    <Datasource>
+        <Parameter name="type">postgis</Parameter>
+        <Parameter name="dbname"><![CDATA[{{dbname}}]]></Parameter>
+        <Parameter name="host"><![CDATA[{{host}}]]></Parameter>
+        <Parameter name="user"><![CDATA[{{user}}]]></Parameter>
+        <Parameter name="password"><![CDATA[{{password}}]]></Parameter>
+        <Parameter name="port"><![CDATA[{{port}}]]></Parameter>
+        <Parameter name="geometry_field"><![CDATA[{{geometry_field}}]]></Parameter>
+        <Parameter name="srid">3857</Parameter>
+        <Parameter name="extent">-20037508.34,-20037508.34,20037508.34,20037508.34</Parameter>
+    </Datasource>
+</Layer>
+</Map>

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
         "lru-cache":"~2.5.0",
         "log4js": "https://github.com/CartoDB/log4js-node/tarball/cdb",
         "rollbar": "~0.3.2",
-        "node-statsd": "~0.0.7"
+        "node-statsd": "~0.0.7",
+        "async": "^0.9.0",
     },
     "devDependencies": {
         "redis": "0.7.1",


### PR DESCRIPTION
This is both incomplete and not really a good idea, but it brings up some points worth discussing, I think.

While writing this (and the TIFF patch), I started wondering about the distinction between the SQL API and the Windshaft-powered endpoints.  Specifically, there feels like there's a lot of overlap between the 2.

The Windshaft endpoints seem like variants of the SQL endpoints that produce tiled data (and images, but I can't think of a good reason that the SQL endpoint shouldn't include those).

This is partially to say that this output format is better suited to Windshaft (but that wasn't where I initially thought to implement it), since it requires that query parameters be passed through (in order to render the PBF) **and** coordinates need to be embedded into the SQL query that's provided (which would be implicit if powered by Windshaft).

Have you guys given any thought to merging the functionality of the 2 sets of endpoints?
