### PR TITLE
Avoid timeouts when ogr2ogr queries pg_* catalog

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 1.22.2 - 2015-mm-dd
 -------------------
 
+Bug fixes:
+
+ * Reintroduces tables= param in ogr2ogr exports (#204)
+   This will avoid running a heavy ogr2ogr query when the pg catalog is big
+   Ref https://github.com/CartoDB/CartoDB-SQL-API/commit/84c422c505391ef0e743aed2204214d4286d7e30
 
 1.22.1 - 2015-05-14
 -------------------

--- a/app/controllers/app.js
+++ b/app/controllers/app.js
@@ -470,7 +470,6 @@ function handleQuery(req, res) {
                 // TODO: drop this, fix UI!
                 sql = new PSQL.QueryWrapper(sql).orderBy(orderBy, sortOrder).window(limit, offset).query();
 
-
                 var opts = {
                   username: cdbUsername,
                   dbopts: dbopts,

--- a/app/controllers/app.js
+++ b/app/controllers/app.js
@@ -286,6 +286,8 @@ function handleQuery(req, res) {
             req.profiler.done('init');
         }
 
+        var affectedTables;
+
         // 1. Get database from redis via the username stored in the host header subdomain
         // 2. Run the request through OAuth to get R/W user id if signed
         // 3. Get the list of tables affected by the query
@@ -404,6 +406,7 @@ function handleQuery(req, res) {
                     };
                     tableCache.set(sql_md5, tableCacheItem);
                 }
+                affectedTables = tables;
 
                 if ( !authenticated && tableCacheItem ) {
                     var affected_tables = tableCacheItem.affected_tables;
@@ -467,6 +470,7 @@ function handleQuery(req, res) {
                 // TODO: drop this, fix UI!
                 sql = new PSQL.QueryWrapper(sql).orderBy(orderBy, sortOrder).window(limit, offset).query();
 
+
                 var opts = {
                   username: cdbUsername,
                   dbopts: dbopts,
@@ -476,6 +480,7 @@ function handleQuery(req, res) {
                   skipfields: skipfields,
                   sql: sql,
                   filename: filename,
+                  affectedTables: affectedTables,
                   bufferedRows: global.settings.bufferedRows,
                   callback: params.callback,
                   abortChecker: checkAborted

--- a/app/models/formats/ogr.js
+++ b/app/models/formats/ogr.js
@@ -141,12 +141,18 @@ OgrFormat.prototype.toOGR = function(options, out_format, out_filename, callback
 
       var ogrsql = 'SELECT ' + columns.join(',') + ' FROM (' + sql + ') as _cartodbsqlapi';
 
+      var tables = 'fake';
+      if (options.affectedTables && options.affectedTables.length) {
+          tables = options.affectedTables.join(',');
+      }
+
       var ogrargs = [
         '-f', out_format,
         '-lco', 'ENCODING=UTF-8',
         '-lco', 'LINEFORMAT=CRLF',
         out_filename,
         "PG:host=" + dbhost + " port=" + dbport + " user=" + dbuser + " dbname=" + dbname + " password=" + dbpass,
+        'tables=' + tables,
         '-sql', ogrsql
       ];
 


### PR DESCRIPTION
Reintroduces tables= param in ogr2ogr exports

Fixes #204 

This will avoid running a heavy ogr2ogr query when the pg catalog is big

Ref https://github.com/CartoDB/CartoDB-SQL-API/commit/84c422c505391ef0e743aed2204214d4286d7e30