### PR TITLE
Uses :remote-addr instead of :req[X-Real-IP]

### DIFF
--- a/app/controllers/app.js
+++ b/app/controllers/app.js
@@ -77,7 +77,7 @@ var tableCache = LRU({
 var loggerOpts = {
     buffer: true,
     format: global.settings.log_format ||
-            ':req[X-Real-IP] :method :req[Host]:url :status :response-time ms -> :res[Content-Type]'
+            ':remote-addr :method :req[Host]:url :status :response-time ms -> :res[Content-Type]'
 };
 
 if ( global.log4js ) {

--- a/config/environments/development.js.example
+++ b/config/environments/development.js.example
@@ -5,7 +5,7 @@ module.exports.base_url     = '(?:/api/:version|/user/:user/api/:version)';
 // X-SQLAPI-Profile header containing elapsed timing for various
 // steps taken for producing the response.
 module.exports.useProfiler = true;
-module.exports.log_format   = '[:date] :req[X-Real-IP] :method :req[Host]:url :status :response-time ms -> :res[Content-Type] (:res[X-SQLAPI-Profiler])';
+module.exports.log_format   = '[:date] :remote-addr :method :req[Host]:url :status :response-time ms -> :res[Content-Type] (:res[X-SQLAPI-Profiler])';
 // If log_filename is given logs will be written there, in append mode. Otherwise stdout is used (default).
 // Log file will be re-opened on receiving the HUP signal
 module.exports.log_filename = 'logs/cartodb-sql-api.log';

--- a/config/environments/production.js.example
+++ b/config/environments/production.js.example
@@ -5,7 +5,7 @@ module.exports.base_url     = '(?:/api/:version|/user/:user/api/:version)';
 // X-SQLAPI-Profile header containing elapsed timing for various
 // steps taken for producing the response.
 module.exports.useProfiler = true;
-module.exports.log_format   = '[:date] :req[X-Real-IP] :method :req[Host]:url :status :response-time ms -> :res[Content-Type] (:res[X-SQLAPI-Profiler])';
+module.exports.log_format   = '[:date] :remote-addr :method :req[Host]:url :status :response-time ms -> :res[Content-Type] (:res[X-SQLAPI-Profiler])';
 // If log_filename is given logs will be written there, in append mode. Otherwise stdout is used (default).
 // Log file will be re-opened on receiving the HUP signal
 module.exports.log_filename = 'logs/cartodb-sql-api.log';

--- a/config/environments/test.js.example
+++ b/config/environments/test.js.example
@@ -5,7 +5,7 @@ module.exports.base_url     = '(?:/api/:version|/user/:user/api/:version)';
 // X-SQLAPI-Profile header containing elapsed timing for various
 // steps taken for producing the response.
 module.exports.useProfiler = true;
-module.exports.log_format   = '[:date] :req[X-Real-IP] :method :req[Host]:url :status :response-time ms -> :res[Content-Type] (:res[X-SQLAPI-Profiler])';
+module.exports.log_format   = '[:date] :remote-addr :method :req[Host]:url :status :response-time ms -> :res[Content-Type] (:res[X-SQLAPI-Profiler])';
 // If log_filename is given logs will be written there, in append mode. Otherwise stdout is used (default).
 // Log file will be re-opened on receiving the HUP signal
 // module.exports.log_filename = 'logs/cartodb-sql-api.log';


### PR DESCRIPTION
Fixes #197 (I think)

Gets the requester's IP address via ```:remote-addr``` on the logging template. @rochoa is this an equivalent solution? I'm not that sure.