### PR TITLE
Adds SpatiaLite as export format

### DIFF
--- a/app/models/formats/ogr.js
+++ b/app/models/formats/ogr.js
@@ -164,10 +164,6 @@ OgrFormat.prototype.toOGR = function(options, out_format, out_filename, callback
         ogrargs.push('-nlt', type);
       }
 
-      if ( out_format === 'SQLite' ) {
-        ogrargs.push('SPATIALITE=yes');
-      }
-
       ogrargs.push('-nln', out_layername);
 
       var child = spawn(ogr2ogr, ogrargs);

--- a/app/models/formats/ogr.js
+++ b/app/models/formats/ogr.js
@@ -164,6 +164,12 @@ OgrFormat.prototype.toOGR = function(options, out_format, out_filename, callback
         ogrargs.push('-nlt', type);
       }
 
+      if (options.cmd_params){
+        options.cmd_params.forEach(function(param){
+          ogrargs.push(param);
+        });
+      }
+
       ogrargs.push('-nln', out_layername);
 
       var child = spawn(ogr2ogr, ogrargs);

--- a/app/models/formats/ogr.js
+++ b/app/models/formats/ogr.js
@@ -165,9 +165,7 @@ OgrFormat.prototype.toOGR = function(options, out_format, out_filename, callback
       }
 
       if (options.cmd_params){
-        options.cmd_params.forEach(function(param){
-          ogrargs.push(param);
-        });
+        ogrargs.concat(options.cmd_params);
       }
 
       ogrargs.push('-nln', out_layername);

--- a/app/models/formats/ogr.js
+++ b/app/models/formats/ogr.js
@@ -164,6 +164,10 @@ OgrFormat.prototype.toOGR = function(options, out_format, out_filename, callback
         ogrargs.push('-nlt', type);
       }
 
+      if ( out_format === 'SQLite' ) {
+        ogrargs.push('SPATIALITE=yes');
+      }
+
       ogrargs.push('-nln', out_layername);
 
       var child = spawn(ogr2ogr, ogrargs);

--- a/app/models/formats/ogr/spatialite.js
+++ b/app/models/formats/ogr/spatialite.js
@@ -17,7 +17,7 @@ SpatiaLiteFormat.prototype._needSRS = true;
 
 SpatiaLiteFormat.prototype.generate = function(options, callback) {
     var ogrFormat = 'SQLite SPATIALITE=yes';
-    this.toOGR_SingleFile(options, 'SQLite', callback);
+    this.toOGR_SingleFile(options, ogrFormat, callback);
 };
 
 module.exports = SpatiaLiteFormat;

--- a/app/models/formats/ogr/spatialite.js
+++ b/app/models/formats/ogr/spatialite.js
@@ -16,8 +16,8 @@ SpatiaLiteFormat.prototype._fileExtension = "sqlite";
 SpatiaLiteFormat.prototype._needSRS = true;
 
 SpatiaLiteFormat.prototype.generate = function(options, callback) {
-    var ogrFormat = 'SQLite SPATIALITE=yes';
-    this.toOGR_SingleFile(options, ogrFormat, callback);
+    this.toOGR_SingleFile(options, 'SQLite', callback);
+    options.cmd_params = ['SPATIALITE=yes'];
 };
 
 module.exports = SpatiaLiteFormat;

--- a/app/models/formats/ogr/spatialite.js
+++ b/app/models/formats/ogr/spatialite.js
@@ -16,6 +16,7 @@ SpatiaLiteFormat.prototype._fileExtension = "sqlite";
 SpatiaLiteFormat.prototype._needSRS = true;
 
 SpatiaLiteFormat.prototype.generate = function(options, callback) {
+    var ogrFormat = 'SQLite SPATIALITE=yes';
     this.toOGR_SingleFile(options, 'SQLite', callback);
 };
 

--- a/app/models/formats/ogr/spatialite.js
+++ b/app/models/formats/ogr/spatialite.js
@@ -1,0 +1,22 @@
+var ogr = require('./../ogr');
+
+function SpatiaLiteFormat() {}
+
+SpatiaLiteFormat.prototype = new ogr('spatialite');
+
+SpatiaLiteFormat.prototype._contentType = "application/x-sqlite3; charset=utf-8";
+SpatiaLiteFormat.prototype._fileExtension = "sqlite";
+// As of GDAL 1.10.1 SRID detection is bogus, so we use
+// our own method. See:
+//  http://trac.osgeo.org/gdal/ticket/5131
+//  http://trac.osgeo.org/gdal/ticket/5287
+//  http://github.com/CartoDB/CartoDB-SQL-API/issues/110
+//  http://github.com/CartoDB/CartoDB-SQL-API/issues/116
+// Bug was fixed in GDAL 1.10.2
+SpatiaLiteFormat.prototype._needSRS = true;
+
+SpatiaLiteFormat.prototype.generate = function(options, callback) {
+    this.toOGR_SingleFile(options, 'SQLite', callback);
+};
+
+module.exports = SpatiaLiteFormat;

--- a/doc/API.md
+++ b/doc/API.md
@@ -161,7 +161,7 @@ https://{account}.cartodb.com/api/v2/sql?format=GeoJSON&q=SELECT * FROM {table_n
 }
 ```
 
-The SQL API accepts other output formats that can be useful to export data. Right now you can use the following formats: CSV, SHP, SVG, KML, and GeoJSON.
+The SQL API accepts other output formats that can be useful to export data. Right now you can use the following formats: CSV, SHP, SVG, KML, SpatiaLite and GeoJSON.
 
 ### Output filename
 To customize the output filename, add the `filename` parameter to your URL:

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
         "mocha": "~1.21.4",
         "jshint": "~2.6.0",
         "zipfile": "~0.5.0",
-        "libxmljs": "~0.8.1"
+        "libxmljs": "~0.8.1",
+        "sqlite3": "~3.0.8"
     },
     "scripts": {
         "test": "make test-all"

--- a/test/acceptance/export/spatialite.js
+++ b/test/acceptance/export/spatialite.js
@@ -3,25 +3,50 @@ var assert = require('../../support/assert');
 var sqlite = require('sqlite3');
 
 describe.only('spatialite query',function(){
-    var serverResponse;
 
-    before(function(done){
+    it('returns a valid sqlite database', function(done){
         assert.response(app, {
             url: '/api/v1/sql?q=SELECT%20*%20FROM%20untitle_table_4%20LIMIT%201&format=spatialite',
             headers: {host: 'vizzuality.cartodb.com'},
             method: 'GET'
         },{ }, function(res) {
-            serverResponse = res;
+            assert.equal(res.statusCode, 200, res.body);
+            assert.equal(res.headers["content-type"], "application/x-sqlite3; charset=utf-8");
+            var db = new sqlite.Database(res.body);
+            var qr = db.get("PRAGMA database_list", function(err){
+                assert.equal(err, null);
+                done();
+            });
+            assert.notEqual(qr, undefined);
+        });
+
+    });
+
+    it('different file name', function(done){
+        assert.response(app, {
+            url: '/api/v1/sql?q=SELECT%20*%20FROM%20untitle_table_4%20LIMIT%201&format=spatialite&filename=manolo',
+            headers: {host: 'vizzuality.cartodb.com'},
+            method: 'GET'
+        },{ }, function(res) {
+            assert.equal(res.headers["content-type"], "application/x-sqlite3; charset=utf-8");
+            assert.notEqual(res.headers["content-disposition"].indexOf("manolo.sqlite"), -1);
             done();
         });
     });
-    it('returns a valid sqlite database', function(done){
-        assert.equal(serverResponse.statusCode, 200, serverResponse.body);
-        var db = new sqlite.Database(serverResponse.body);
-        var qr = db.get("PRAGMA database_list", function(err, result){
-            assert.equal(err, null);
-            done();
+
+    it('gets database schema', function(done){
+        assert.response(app, {
+            url: '/api/v1/sql?q=SELECT%20*%20FROM%20untitle_table_4%20LIMIT%201&format=spatialite',
+            headers: {host: 'vizzuality.cartodb.com'},
+            method: 'GET'
+        },{ }, function(res) {
+            var db = new sqlite.Database(res.body);
+            var schemaQuery = "SELECT name, sql FROM sqlite_master WHERE type='table' ORDER BY name";
+            var qr = db.get(schemaQuery, function(err){
+                assert.equal(err, null);
+                done();
+            });
+            assert.notEqual(qr, undefined);
         });
-        assert.notEqual(qr, undefined);
     });
 });

--- a/test/acceptance/export/spatialite.js
+++ b/test/acceptance/export/spatialite.js
@@ -2,7 +2,7 @@ var app = require(global.settings.app_root + '/app/controllers/app')();
 var assert = require('../../support/assert');
 var sqlite = require('sqlite3');
 
-describe.only('spatialite query',function(){
+describe('spatialite query', function(){
 
     it('returns a valid sqlite database', function(done){
         assert.response(app, {

--- a/test/acceptance/export/spatialite.js
+++ b/test/acceptance/export/spatialite.js
@@ -1,0 +1,27 @@
+var app = require(global.settings.app_root + '/app/controllers/app')();
+var assert = require('../../support/assert');
+var sqlite = require('sqlite3');
+
+describe.only('spatialite query',function(){
+    var serverResponse;
+
+    before(function(done){
+        assert.response(app, {
+            url: '/api/v1/sql?q=SELECT%20*%20FROM%20untitle_table_4%20LIMIT%201&format=spatialite',
+            headers: {host: 'vizzuality.cartodb.com'},
+            method: 'GET'
+        },{ }, function(res) {
+            serverResponse = res;
+            done();
+        });
+    });
+    it('returns a valid sqlite database', function(done){
+        assert.equal(serverResponse.statusCode, 200, serverResponse.body);
+        var db = new sqlite.Database(serverResponse.body);
+        var qr = db.get("PRAGMA database_list", function(err, result){
+            assert.equal(err, null);
+            done();
+        });
+        assert.notEqual(qr, undefined);
+    });
+});


### PR DESCRIPTION
Closes #226 

![sqlite](https://cloud.githubusercontent.com/assets/3707222/7913634/d2dd2362-0871-11e5-9f50-32ad6ee2e8fc.gif)

Adds the SQLite-based SpatiaLite file format as supported export format, in order to improve integration with QGIS.

@rochoa @javisantana @andrewxhill 

 