### PR TITLE
Fix X-Cache-Channel generation when request are not authenticated

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 1.25.1 - 2016-mm-dd
 -------------------
 
+Bug fixes:
+
+ * Fix X-Cache-Channel generation when request are not authenticated #266
+
 
 1.25.0 - 2016-01-26
 -------------------

--- a/app/app.js
+++ b/app/app.js
@@ -29,6 +29,7 @@ var UserIndexer = require('../batch/user_indexer');
 var JobBackend = require('../batch/job_backend');
 var JobCanceller = require('../batch/job_canceller');
 var UserDatabaseMetadataService = require('../batch/user_database_metadata_service');
+var QueryTablesApi = require('./services/query-tables-api');
 
 var cors = require('./middlewares/cors');
 
@@ -70,6 +71,7 @@ function App() {
       // consider entries expired after these many milliseconds (10 minutes by default)
       maxAge: global.settings.tableCacheMaxAge || 1000*60*10
     });
+    var queryTablesApi = new QueryTablesApi(tableCache);
 
     // Size based on https://github.com/CartoDB/cartodb.js/blob/3.15.2/src/geo/layer_definition.js#L72
     var SQL_QUERY_BODY_LOG_MAX_LENGTH = 2000;
@@ -188,7 +190,7 @@ function App() {
     var genericController = new GenericController();
     genericController.route(app);
 
-    var queryController = new QueryController(userDatabaseService, tableCache, statsd_client);
+    var queryController = new QueryController(userDatabaseService, queryTablesApi, statsd_client);
     queryController.route(app);
 
     var jobController = new JobController(userDatabaseService, jobBackend, jobCanceller);

--- a/app/app.js
+++ b/app/app.js
@@ -191,7 +191,7 @@ function App() {
     var queryController = new QueryController(userDatabaseService, tableCache, statsd_client);
     queryController.route(app);
 
-    var jobController = new JobController(userDatabaseService, jobBackend, jobCanceller, tableCache, statsd_client);
+    var jobController = new JobController(userDatabaseService, jobBackend, jobCanceller);
     jobController.route(app);
 
     var cacheStatusController = new CacheStatusController(tableCache);

--- a/app/controllers/job_controller.js
+++ b/app/controllers/job_controller.js
@@ -41,7 +41,7 @@ JobController.prototype.cancelJob = function (req, res) {
             var next = this;
             var authApi = new AuthApi(req, params);
 
-            self.userDatabaseService.getUserDatabase(authApi, cdbUsername, next);
+            self.userDatabaseService.getConnectionParams(authApi, cdbUsername, next);
         },
         function cancelJob(err, userDatabase) {
             assert.ifError(err);
@@ -106,7 +106,7 @@ JobController.prototype.listJob = function (req, res) {
             var next = this;
             var authApi = new AuthApi(req, params);
 
-            self.userDatabaseService.getUserDatabase(authApi, cdbUsername, next);
+            self.userDatabaseService.getConnectionParams(authApi, cdbUsername, next);
         },
         function listJob(err, userDatabase) {
             assert.ifError(err);
@@ -172,7 +172,7 @@ JobController.prototype.getJob = function (req, res) {
             var next = this;
             var authApi = new AuthApi(req, params);
 
-            self.userDatabaseService.getUserDatabase(authApi, cdbUsername, next);
+            self.userDatabaseService.getConnectionParams(authApi, cdbUsername, next);
         },
         function getJob(err, userDatabase) {
             assert.ifError(err);
@@ -242,7 +242,7 @@ JobController.prototype.createJob = function (req, res) {
             var next = this;
             var authApi = new AuthApi(req, params);
 
-            self.userDatabaseService.getUserDatabase(authApi, cdbUsername, next);
+            self.userDatabaseService.getConnectionParams(authApi, cdbUsername, next);
         },
         function persistJob(err, userDatabase) {
             assert.ifError(err);
@@ -314,7 +314,7 @@ JobController.prototype.updateJob = function (req, res) {
             var next = this;
             var authApi = new AuthApi(req, params);
 
-            self.userDatabaseService.getUserDatabase(authApi, cdbUsername, next);
+            self.userDatabaseService.getConnectionParams(authApi, cdbUsername, next);
         },
         function updateJob(err, userDatabase) {
             assert.ifError(err);

--- a/app/controllers/job_controller.js
+++ b/app/controllers/job_controller.js
@@ -9,12 +9,10 @@ var CdbRequest = require('../models/cartodb_request');
 var handleException = require('../utils/error_handler');
 var cdbReq = new CdbRequest();
 
-function JobController(userDatabaseService, jobBackend, jobCanceller, tableCache, statsd_client) {
+function JobController(userDatabaseService, jobBackend, jobCanceller) {
     this.userDatabaseService = userDatabaseService;
     this.jobBackend = jobBackend;
     this.jobCanceller = jobCanceller;
-    this.tableCache = tableCache;
-    this.statsd_client = statsd_client;
 }
 
 JobController.prototype.route = function (app) {

--- a/app/controllers/query_controller.js
+++ b/app/controllers/query_controller.js
@@ -122,7 +122,7 @@ QueryController.prototype.handleQuery = function (req, res) {
             function getUserDBInfo() {
                 self.userDatabaseService.getConnectionParams(new AuthApi(req, params), cdbUsername, this);
             },
-            function queryExplain(err, dbParams) {
+            function queryExplain(err, dbParams, authDbParams) {
                 assert.ifError(err);
 
                 dbopts = dbParams;
@@ -133,7 +133,7 @@ QueryController.prototype.handleQuery = function (req, res) {
 
                 checkAborted('queryExplain');
 
-                self.queryTablesApi.getAffectedTablesAndLastUpdatedTime(dbParams, sql, this);
+                self.queryTablesApi.getAffectedTablesAndLastUpdatedTime(authDbParams, sql, this);
             },
             function setHeaders(err, queryExplainResult) {
                 assert.ifError(err);

--- a/app/controllers/query_controller.js
+++ b/app/controllers/query_controller.js
@@ -177,8 +177,7 @@ QueryController.prototype.handleQuery = function (req, res) {
 
                 // Only set an X-Cache-Channel for responses we want Varnish to cache.
                 if (queryExplainResult.affectedTables.length > 0 && !queryExplainResult.mayWrite) {
-                  res.header('X-Cache-Channel', generateCacheKey(
-                      dbopts.dbname, queryExplainResult, dbopts.authenticated));
+                    res.header('X-Cache-Channel', generateCacheKey(dbopts.dbname, queryExplainResult.affectedTables));
                 }
 
                 res.header('Last-Modified', new Date(queryExplainResult.lastModified).toUTCString());

--- a/app/controllers/query_controller.js
+++ b/app/controllers/query_controller.js
@@ -120,16 +120,12 @@ QueryController.prototype.handleQuery = function (req, res) {
         // 5. Send formatted results back
         step(
             function getUserDBInfo() {
-                var next = this;
-                var authApi = new AuthApi(req, params);
-
-                self.userDatabaseService.getUserDatabase(authApi, cdbUsername, next);
+                self.userDatabaseService.getConnectionParams(new AuthApi(req, params), cdbUsername, this);
             },
-            function queryExplain(err, userDatabase){
+            function queryExplain(err, dbParams) {
                 assert.ifError(err);
 
-                var next = this;
-                dbopts = userDatabase;
+                dbopts = dbParams;
 
                 if ( req.profiler ) {
                     req.profiler.done('setDBAuth');
@@ -137,7 +133,7 @@ QueryController.prototype.handleQuery = function (req, res) {
 
                 checkAborted('queryExplain');
 
-                self.queryTablesApi.getAffectedTablesAndLastUpdatedTime(userDatabase, sql, this);
+                self.queryTablesApi.getAffectedTablesAndLastUpdatedTime(dbParams, sql, this);
             },
             function setHeaders(err, queryExplainResult) {
                 assert.ifError(err);

--- a/app/controllers/query_controller.js
+++ b/app/controllers/query_controller.js
@@ -11,16 +11,16 @@ var CdbRequest = require('../models/cartodb_request');
 var formats = require('../models/formats');
 
 var sanitize_filename = require('../utils/filename_sanitizer');
-var generateMD5 = require('../utils/md5');
-var queryMayWrite = require('../utils/query_may_write');
 var getContentDisposition = require('../utils/content_disposition');
 var generateCacheKey = require('../utils/cache_key_generator');
 var handleException = require('../utils/error_handler');
 
+var ONE_YEAR_IN_SECONDS = 31536000; // 1 year time to live by default
+
 var cdbReq = new CdbRequest();
 
-function QueryController(userDatabaseService, tableCache, statsd_client) {
-    this.tableCache = tableCache;
+function QueryController(userDatabaseService, queryTablesApi, statsd_client) {
+    this.queryTablesApi = queryTablesApi;
     this.statsd_client = statsd_client;
     this.userDatabaseService = userDatabaseService;
 }
@@ -50,7 +50,6 @@ QueryController.prototype.handleQuery = function (req, res) {
     var skipfields;
     var dp = params.dp; // decimal point digits (defaults to 6)
     var gn = "the_geom"; // TODO: read from configuration file
-    var tableCacheItem;
 
     if ( req.profiler ) {
         req.profiler.start('sqlapi.query');
@@ -107,12 +106,6 @@ QueryController.prototype.handleQuery = function (req, res) {
             throw new Error("You must indicate a sql query");
         }
 
-        // initialise MD5 key of sql for cache lookups
-        var sql_md5 = generateMD5(sql);
-
-        // placeholder for connection
-        var pg;
-
         // Database options
         var dbopts = {};
         var formatter;
@@ -144,46 +137,9 @@ QueryController.prototype.handleQuery = function (req, res) {
 
                 checkAborted('queryExplain');
 
-                pg = new PSQL(dbopts, {}, { destroyOnError: true });
-                // get all the tables from Cache or SQL
-                tableCacheItem = self.tableCache.get(sql_md5);
-                if (tableCacheItem) {
-                   tableCacheItem.hits++;
-                   return false;
-                } else {
-                    var affectedTablesAndLastUpdatedTimeQuery = [
-                        'WITH querytables AS (',
-                            'SELECT * FROM CDB_QueryTablesText($quotesql$' + sql + '$quotesql$) as tablenames',
-                        ')',
-                        'SELECT (SELECT tablenames FROM querytables), EXTRACT(EPOCH FROM max(updated_at)) as max',
-                        'FROM CDB_TableMetadata m',
-                        'WHERE m.tabname = any ((SELECT tablenames from querytables)::regclass[])'
-                    ].join(' ');
-
-                    pg.query(affectedTablesAndLastUpdatedTimeQuery, function (err, resultSet) {
-                        var tableNames = [];
-                        var lastUpdatedTime = Date.now();
-
-                        if (!err && resultSet.rowCount === 1) {
-                            var result = resultSet.rows[0];
-                            // This is an Array, so no need to split into parts
-                            tableNames = result.tablenames;
-                            if (Number.isFinite(result.max)) {
-                                lastUpdatedTime = result.max * 1000;
-                            }
-                        } else {
-                            var errorMessage = (err && err.message) || 'unknown error';
-                            console.error("Error on query explain '%s': %s", sql, errorMessage);
-                        }
-
-                        return next(null, {
-                            affectedTables: tableNames,
-                            lastUpdatedTime: lastUpdatedTime
-                        });
-                    }, true);
-                }
+                self.queryTablesApi.getAffectedTablesAndLastUpdatedTime(userDatabase, sql, this);
             },
-            function setHeaders(err, result) {
+            function setHeaders(err, queryExplainResult) {
                 assert.ifError(err);
 
                 if ( req.profiler ) {
@@ -192,21 +148,8 @@ QueryController.prototype.handleQuery = function (req, res) {
 
                 checkAborted('setHeaders');
 
-                // store explain result in local Cache
-                if ( ! tableCacheItem && result && result.affectedTables ) {
-                    tableCacheItem = {
-                        affected_tables: result.affectedTables,
-                        last_modified: result.lastUpdatedTime,
-                        // check if query may possibly write
-                        may_write: queryMayWrite(sql),
-                        // initialise hit counter
-                        hits: 1
-                    };
-                    self.tableCache.set(sql_md5, tableCacheItem);
-                }
-
-                if ( !dbopts.authenticated && tableCacheItem ) {
-                    var affected_tables = tableCacheItem.affected_tables;
+                if (!dbopts.authenticated) {
+                    var affected_tables = queryExplainResult.affectedTables;
                     for ( var i = 0; i < affected_tables.length; ++i ) {
                         var t = affected_tables[i];
                         if ( t.match(/\bpg_/) ) {
@@ -228,28 +171,21 @@ QueryController.prototype.handleQuery = function (req, res) {
                 res.header("Content-Type", formatter.getContentType());
 
                 // set cache headers
-                var ttl = 31536000; // 1 year time to live by default
-                var cache_policy = req.query.cache_policy;
-                if ( cache_policy === 'persist' ) {
-                  res.header('Cache-Control', 'public,max-age=' + ttl);
+                var cachePolicy = req.query.cache_policy;
+                if (cachePolicy === 'persist') {
+                    res.header('Cache-Control', 'public,max-age=' + ONE_YEAR_IN_SECONDS);
                 } else {
-                  if ( ! tableCacheItem || tableCacheItem.may_write ) {
-                    // Tell clients this response is already expired
-                    // TODO: prevent cache_policy from overriding this ?
-                    ttl = 0;
-                  }
-                  res.header('Cache-Control', 'no-cache,max-age='+ttl+',must-revalidate,public');
+                    var maxAge = (queryExplainResult.mayWrite) ? 0 : ONE_YEAR_IN_SECONDS;
+                    res.header('Cache-Control', 'no-cache,max-age='+maxAge+',must-revalidate,public');
                 }
 
                 // Only set an X-Cache-Channel for responses we want Varnish to cache.
-                if ( tableCacheItem && tableCacheItem.affected_tables.length > 0 && !tableCacheItem.may_write ) {
-                  res.header('X-Cache-Channel', generateCacheKey(dbopts.dbname, tableCacheItem, dbopts.authenticated));
+                if (queryExplainResult.affectedTables.length > 0 && !queryExplainResult.mayWrite) {
+                  res.header('X-Cache-Channel', generateCacheKey(
+                      dbopts.dbname, queryExplainResult, dbopts.authenticated));
                 }
 
-                var lastModified = (tableCacheItem && tableCacheItem.last_modified) ?
-                    tableCacheItem.last_modified :
-                    Date.now();
-                res.header('Last-Modified', new Date(lastModified).toUTCString());
+                res.header('Last-Modified', new Date(queryExplainResult.lastModified).toUTCString());
 
                 return null;
             },

--- a/app/controllers/query_controller.js
+++ b/app/controllers/query_controller.js
@@ -180,7 +180,7 @@ QueryController.prototype.handleQuery = function (req, res) {
                             affectedTables: tableNames,
                             lastUpdatedTime: lastUpdatedTime
                         });
-                    });
+                    }, true);
                 }
             },
             function setHeaders(err, result) {

--- a/app/services/query-tables-api.js
+++ b/app/services/query-tables-api.js
@@ -1,0 +1,62 @@
+var PSQL = require('cartodb-psql');
+
+var generateMD5 = require('../utils/md5');
+var queryMayWrite = require('../utils/query_may_write');
+
+function QueryTablesApi(tableCache) {
+    this.tableCache = tableCache;
+}
+
+module.exports = QueryTablesApi;
+
+QueryTablesApi.prototype.getAffectedTablesAndLastUpdatedTime = function (connectionParams, sql, callback) {
+    var self = this;
+
+    var sqlCacheKey = generateMD5(sql);
+
+    var queryExplainResult = this.tableCache.get(sqlCacheKey);
+
+    if (queryExplainResult) {
+        queryExplainResult.hits++;
+        return callback(null, queryExplainResult);
+    }
+
+
+    var query = [
+        'WITH querytables AS (',
+            'SELECT * FROM CDB_QueryTablesText($quotesql$' + sql + '$quotesql$) as tablenames',
+        ')',
+        'SELECT (SELECT tablenames FROM querytables), EXTRACT(EPOCH FROM max(updated_at)) as max',
+        'FROM CDB_TableMetadata m',
+        'WHERE m.tabname = any ((SELECT tablenames from querytables)::regclass[])'
+    ].join(' ');
+
+    var pg = new PSQL(connectionParams, {}, { destroyOnError: true });
+
+    pg.query(query, function handleAffectedTablesAndLastUpdatedTimeRows(err, resultSet) {
+        resultSet = resultSet || {};
+        var rows = resultSet.rows || [];
+
+        if (err || rows.length !== 1) {
+            var errorMessage = (err && err.message) || 'unknown error';
+            console.error("Error on query explain '%s': %s", sql, errorMessage);
+        }
+
+        var result = rows[0] || {};
+
+        // This is an Array, so no need to split into parts
+        var tableNames = result.tablenames || [];
+        var lastUpdatedTime = (Number.isFinite(result.max)) ? (result.max * 1000) : Date.now();
+
+        var queryExplainResult = {
+            affectedTables: tableNames,
+            lastModified: lastUpdatedTime,
+            mayWrite: queryMayWrite(sql),
+            hits: 1
+        };
+
+        self.tableCache.set(sqlCacheKey, queryExplainResult);
+
+        return callback(null, queryExplainResult);
+    }, true);
+};

--- a/app/services/query-tables-api.js
+++ b/app/services/query-tables-api.js
@@ -12,9 +12,8 @@ module.exports = QueryTablesApi;
 QueryTablesApi.prototype.getAffectedTablesAndLastUpdatedTime = function (connectionParams, sql, callback) {
     var self = this;
 
-    var sqlCacheKey = generateMD5(sql);
-
-    var queryExplainResult = this.tableCache.get(sqlCacheKey);
+    var cacheKey = sqlCacheKey(connectionParams.user, sql);
+    var queryExplainResult = this.tableCache.get(cacheKey);
 
     if (queryExplainResult) {
         queryExplainResult.hits++;
@@ -52,7 +51,7 @@ QueryTablesApi.prototype.getAffectedTablesAndLastUpdatedTime = function (connect
             hits: 1
         };
 
-        self.tableCache.set(sqlCacheKey, queryExplainResult);
+        self.tableCache.set(cacheKey, queryExplainResult);
 
         return callback(null, queryExplainResult);
     }, true);
@@ -63,4 +62,8 @@ function logIfError(err, sql, rows) {
         var errorMessage = (err && err.message) || 'unknown error';
         console.error("Error on query explain '%s': %s", sql, errorMessage);
     }
+}
+
+function sqlCacheKey(user, sql) {
+    return user + ':' + generateMD5(sql);
 }

--- a/app/services/query-tables-api.js
+++ b/app/services/query-tables-api.js
@@ -37,10 +37,7 @@ QueryTablesApi.prototype.getAffectedTablesAndLastUpdatedTime = function (connect
         resultSet = resultSet || {};
         var rows = resultSet.rows || [];
 
-        if (err || rows.length !== 1) {
-            var errorMessage = (err && err.message) || 'unknown error';
-            console.error("Error on query explain '%s': %s", sql, errorMessage);
-        }
+        logIfError(err, sql, rows);
 
         var result = rows[0] || {};
 
@@ -60,3 +57,10 @@ QueryTablesApi.prototype.getAffectedTablesAndLastUpdatedTime = function (connect
         return callback(null, queryExplainResult);
     }, true);
 };
+
+function logIfError(err, sql, rows) {
+    if (err || rows.length !== 1) {
+        var errorMessage = (err && err.message) || 'unknown error';
+        console.error("Error on query explain '%s': %s", sql, errorMessage);
+    }
+}

--- a/app/services/user_database_service.js
+++ b/app/services/user_database_service.js
@@ -7,6 +7,16 @@ function UserDatabaseService(metadataBackend) {
     this.metadataBackend = metadataBackend;
 }
 
+/**
+ * Callback is invoked with `dbParams` and `authDbParams`.
+ * `dbParams` depends on AuthApi verification so it might return a public user with just SELECT permission, where
+ * `authDbParams` will always return connection params as AuthApi had authorized the connection.
+ * That might be useful when you have to run a query with and without permissions.
+ *
+ * @param {AuthApi} authApi
+ * @param {String} cdbUsername
+ * @param {Function} callback (err, dbParams, authDbParams)
+ */
 UserDatabaseService.prototype.getConnectionParams = function (authApi, cdbUsername, callback) {
     var self = this;
 

--- a/app/services/user_database_service.js
+++ b/app/services/user_database_service.js
@@ -7,7 +7,7 @@ function UserDatabaseService(metadataBackend) {
     this.metadataBackend = metadataBackend;
 }
 
-UserDatabaseService.prototype.getUserDatabase = function (authApi, cdbUsername, callback) {
+UserDatabaseService.prototype.getConnectionParams = function (authApi, cdbUsername, callback) {
     var self = this;
 
     var dbParams;

--- a/app/services/user_database_service.js
+++ b/app/services/user_database_service.js
@@ -7,8 +7,7 @@ function UserDatabaseService(metadataBackend) {
     this.metadataBackend = metadataBackend;
 }
 
-UserDatabaseService.prototype.getUserDatabase =
-function (authApi, cdbUsername, callback) {
+UserDatabaseService.prototype.getUserDatabase = function (authApi, cdbUsername, callback) {
     var self = this;
 
     var dbParams;

--- a/app/services/user_database_service.js
+++ b/app/services/user_database_service.js
@@ -76,7 +76,7 @@ UserDatabaseService.prototype.getConnectionParams = function (authApi, cdbUserna
                 return callback(err);
             }
 
-            callback(null, dbopts);
+            callback(null, dbopts, dbopts);
         }
     );
 

--- a/app/utils/cache_key_generator.js
+++ b/app/utils/cache_key_generator.js
@@ -1,9 +1,5 @@
 'use strict';
 
-module.exports = function generateCacheKey(database, query_info, is_authenticated){
-    if ( ! query_info || ( is_authenticated && query_info.may_write ) ) {
-      return "NONE";
-    } else {
-      return database + ":" + query_info.affected_tables.join(',');
-    }
+module.exports = function generateCacheKey(database, affectedTables) {
+    return database + ":" + affectedTables.join(',');
 };

--- a/test/test.sql
+++ b/test/test.sql
@@ -148,5 +148,4 @@ CREATE TABLE IF NOT EXISTS
 INSERT INTO CDB_TableMetadata (tabname, updated_at) VALUES ('untitle_table_4'::regclass, '2014-01-01T23:31:30.123Z');
 INSERT INTO CDB_TableMetadata (tabname, updated_at) VALUES ('private_table'::regclass, '2015-01-01T23:31:30.123Z');
 
--- GRANT SELECT ON CDB_TableMetadata TO :PUBLICUSER;
 GRANT SELECT ON CDB_TableMetadata TO :TESTUSER;

--- a/test/test.sql
+++ b/test/test.sql
@@ -148,5 +148,5 @@ CREATE TABLE IF NOT EXISTS
 INSERT INTO CDB_TableMetadata (tabname, updated_at) VALUES ('untitle_table_4'::regclass, '2014-01-01T23:31:30.123Z');
 INSERT INTO CDB_TableMetadata (tabname, updated_at) VALUES ('private_table'::regclass, '2015-01-01T23:31:30.123Z');
 
-GRANT SELECT ON CDB_TableMetadata TO :PUBLICUSER;
+-- GRANT SELECT ON CDB_TableMetadata TO :PUBLICUSER;
 GRANT SELECT ON CDB_TableMetadata TO :TESTUSER;


### PR DESCRIPTION
This changes UserDatabaseService to retrieve all connection params in two different objects so it is possible to run queries with the authenticated user to retrieve information from CDB_TableMetadata, but it keeps the normal behaviour for the user query.

Fixes #265 