### PR TITLE
Geopackage format support #291

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 Announcements:
  - Upgrades step-profiler to 0.3.0 to avoid dots in json keys #294
 
+ New features:
+
+  * Add support for geopackage format (`format=gpkg` at the URL) #291
 
 1.27.1 - 2016-04-18
 -------------------

--- a/app/models/formats/ogr/geopackage.js
+++ b/app/models/formats/ogr/geopackage.js
@@ -1,0 +1,22 @@
+var ogr = require('./../ogr');
+
+function GeoPackageFormat() {}
+
+GeoPackageFormat.prototype = new ogr('geopackage');
+
+GeoPackageFormat.prototype._contentType = "application/x-sqlite3; charset=utf-8";
+GeoPackageFormat.prototype._fileExtension = "gpkg";
+// As of GDAL 1.10.1 SRID detection is bogus, so we use
+// our own method. See:
+//  http://trac.osgeo.org/gdal/ticket/5131
+//  http://trac.osgeo.org/gdal/ticket/5287
+//  http://github.com/CartoDB/CartoDB-SQL-API/issues/110
+//  http://github.com/CartoDB/CartoDB-SQL-API/issues/116
+// Bug was fixed in GDAL 1.10.2
+GeoPackageFormat.prototype._needSRS = true;
+
+GeoPackageFormat.prototype.generate = function(options, callback) {
+    this.toOGR_SingleFile(options, 'GPKG', callback);
+};
+
+module.exports = GeoPackageFormat;

--- a/app/models/formats/ogr/geopackage.js
+++ b/app/models/formats/ogr/geopackage.js
@@ -2,7 +2,7 @@ var ogr = require('./../ogr');
 
 function GeoPackageFormat() {}
 
-GeoPackageFormat.prototype = new ogr('geopackage');
+GeoPackageFormat.prototype = new ogr('gpkg');
 
 GeoPackageFormat.prototype._contentType = "application/x-sqlite3; charset=utf-8";
 GeoPackageFormat.prototype._fileExtension = "gpkg";

--- a/test/acceptance/export/geopackage.js
+++ b/test/acceptance/export/geopackage.js
@@ -7,20 +7,20 @@ var fs      = require('fs');
 
 describe('geopackage query', function(){
     // Default name, cartodb-query, fails because of the hyphen.
-    var table_name = 'a_gpkg_table'
+    var table_name = 'a_gpkg_table';
+    var base_url = '/api/v1/sql?q=SELECT%20*%20FROM%20untitle_table_4%20LIMIT%201&format=gpkg&filename=' + table_name;
 
     it('returns a valid geopackage database', function(done){
         assert.response(app, {
-            url: '/api/v1/sql?q=SELECT%20*%20FROM%20untitle_table_4%20LIMIT%201&format=geopackage&filename=' + table_name,
+            url: base_url,
             headers: {host: 'vizzuality.cartodb.com'},
             method: 'GET'
         },{ }, function(res) {
             assert.equal(res.statusCode, 200, res.body);
             assert.equal(res.headers["content-type"], "application/x-sqlite3; charset=utf-8");
-            console.log(res.headers["content-disposition"])
             assert.notEqual(res.headers["content-disposition"].indexOf(table_name + ".gpkg"), -1);
             var db = new sqlite.Database(':memory:', res.body);
-            var qr = db.get("PRAGMA database_list", function(err){
+            var qr = db.get("PRAGMA database_list", function(err) {
                 assert.equal(err, null);
                 done();
             });
@@ -31,7 +31,7 @@ describe('geopackage query', function(){
 
     it('gets database and geopackage schema', function(done){
         assert.response(app, {
-            url: '/api/v1/sql?q=SELECT%20*%20FROM%20untitle_table_4%20LIMIT%201&format=geopackage&filename=' + table_name,
+            url: base_url,
             headers: {host: 'vizzuality.cartodb.com'},
             encoding: 'binary',
             method: 'GET'

--- a/test/acceptance/export/geopackage.js
+++ b/test/acceptance/export/geopackage.js
@@ -1,0 +1,54 @@
+require('../../helper');
+
+var app = require(global.settings.app_root + '/app/app')();
+var assert = require('../../support/assert');
+var sqlite = require('sqlite3');
+
+describe('geopackage query', function(){
+    // Default name, cartodb-query, fails because of the hyphen.
+    var table_name = 'a_gpkg_table'
+
+    it('returns a valid geopackage database', function(done){
+        assert.response(app, {
+            url: '/api/v1/sql?q=SELECT%20*%20FROM%20untitle_table_4%20LIMIT%201&format=geopackage&filename=' + table_name,
+            headers: {host: 'vizzuality.cartodb.com'},
+            method: 'GET'
+        },{ }, function(res) {
+            assert.equal(res.statusCode, 200, res.body);
+            assert.equal(res.headers["content-type"], "application/x-sqlite3; charset=utf-8");
+            console.log(res.headers["content-disposition"])
+            assert.notEqual(res.headers["content-disposition"].indexOf(table_name + ".gpkg"), -1);
+            var db = new sqlite.Database(':memory:', res.body);
+            var qr = db.get("PRAGMA database_list", function(err){
+                assert.equal(err, null);
+                done();
+            });
+            assert.notEqual(qr, undefined);
+        });
+
+    });
+
+    it('gets database and geopackage schema', function(done){
+        assert.response(app, {
+            url: '/api/v1/sql?q=SELECT%20*%20FROM%20untitle_table_4%20LIMIT%201&format=geopackage&filename=' + table_name,
+            headers: {host: 'vizzuality.cartodb.com'},
+            method: 'GET'
+        },{ }, function(res) {
+            var db = new sqlite.Database(':memory:', res.body);
+            var schemaQuery = "SELECT name, sql FROM sqlite_master WHERE type='table' ORDER BY name";
+            var qr = db.get(schemaQuery, function(err){
+                assert.equal(err, null);
+                done();
+            });
+            assert.notEqual(qr, undefined);
+
+            var gpkgQuery = "SELECT table_name FROM gpkg_contents";
+            var gqr = db.get(gpkgQuery, function(err){
+                assert.equal(err, null);
+                done();
+            });
+            assert.notEqual(gqr, undefined);
+        });
+    });
+
+});

--- a/test/acceptance/export/geopackage.js
+++ b/test/acceptance/export/geopackage.js
@@ -3,6 +3,7 @@ require('../../helper');
 var app = require(global.settings.app_root + '/app/app')();
 var assert = require('../../support/assert');
 var sqlite = require('sqlite3');
+var fs      = require('fs');
 
 describe('geopackage query', function(){
     // Default name, cartodb-query, fails because of the hyphen.
@@ -32,22 +33,46 @@ describe('geopackage query', function(){
         assert.response(app, {
             url: '/api/v1/sql?q=SELECT%20*%20FROM%20untitle_table_4%20LIMIT%201&format=geopackage&filename=' + table_name,
             headers: {host: 'vizzuality.cartodb.com'},
+            encoding: 'binary',
             method: 'GET'
         },{ }, function(res) {
-            var db = new sqlite.Database(':memory:', res.body);
-            var schemaQuery = "SELECT name, sql FROM sqlite_master WHERE type='table' ORDER BY name";
-            var qr = db.get(schemaQuery, function(err){
-                assert.equal(err, null);
-                done();
-            });
-            assert.notEqual(qr, undefined);
+            var tmpfile = '/tmp/a_geopackage_file.gpkg';
+            try {
+              fs.writeFileSync(tmpfile, res.body, 'binary');
+            } catch(err) {
+              return done(err);
+            }
 
-            var gpkgQuery = "SELECT table_name FROM gpkg_contents";
-            var gqr = db.get(gpkgQuery, function(err){
-                assert.equal(err, null);
-                done();
+            var db = new sqlite.Database(tmpfile, function(err) {
+              if(!!err) {
+                return done(err);
+              }
+
+              db.serialize(function() {
+                var schemaQuery = "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name";
+                var sqr = db.get(schemaQuery, function(err, row) {
+                  assert.equal(err, null);
+                  assert.equal(row.name, table_name);
+                });
+                assert.notEqual(sqr, undefined);
+
+                var gpkgQuery = "SELECT table_name FROM gpkg_contents";
+                var gqr = db.get(gpkgQuery, function(err, row) {
+                  assert.equal(row.table_name, table_name);
+                  assert.equal(err, null);
+                });
+                assert.notEqual(gqr, undefined);
+
+                var dataQuery = "SELECT * FROM " + table_name + " order by cartodb_id";
+                var dqr = db.get(dataQuery, function(err, row) {
+                  assert.equal(err, null);
+                  assert.equal(row.cartodb_id, 1);
+                  assert.equal(row.name, 'Hawai');
+                  done();
+                });
+                assert.notEqual(dqr, undefined);
+              });
             });
-            assert.notEqual(gqr, undefined);
         });
     });
 


### PR DESCRIPTION
**DO NOT MERGE YET**

@rochoa I still have to test this, including editor importing as well, but it seems that the basic export works. As you see is almost a duplication from SpatiaLite format.

I have issues with the second test because of my SQLite ignorance. I'd like to check that `gpkg_contents`, one of the GeoPackage metadata columns, exist, but it won't work. If I export the file I can query both `sqlite_master` and `gpkg_contents`, but the test triggers this error for the second one:

```
  1) geopackage query gets database and geopackage schema:
     Uncaught AssertionError: {"errno":1,"code":"SQLITE_ERROR"} == null
      at test/acceptance/export/geopackage.js:47:24
      at Statement.errBack (node_modules/sqlite3/lib/sqlite3.js:16:21)
```

Can you see what I am doing wrong?