### PR TITLE
Fix control flow when using OGR with _needSRS=true and empty queries

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 1.28.1 - 2016-mm-dd
 -------------------
 
+Bug fixes:
+ * OGR with _needSRS=true fails for empty tables #299
+
 
 1.28.0 - 2016-05-11
 -------------------

--- a/app/models/formats/ogr.js
+++ b/app/models/formats/ogr.js
@@ -130,6 +130,9 @@ OgrFormat.prototype.toOGR = function(options, out_format, out_filename, callback
           var srid = result.rows[0].srid;
           var type = result.rows[0].type;
           next(null, srid, type);
+        } else {
+          // continue as srid and geom type are not critical when there are no results
+          next(null);
         }
       });
 

--- a/test/acceptance/export/kml.js
+++ b/test/acceptance/export/kml.js
@@ -397,4 +397,28 @@ it('check point coordinates, authenticated', function(done){
         );
     });
 
+    it('should work with queries returning no results', function(done) {
+        assert.response(
+            app,
+            {
+                url: "/api/v1/sql?" + querystring.stringify({
+                    q: "SELECT * FROM populated_places_simple_reduced LIMIT 0",
+                    format: 'kml'
+                }),
+                headers: {
+                    host: 'vizzuality.cartodb.com'
+                },
+                encoding: 'binary',
+                method: 'GET'
+            },
+            {
+                status: 200
+            },
+            function(res) {
+                assert.equal(res.body.match(/<Placemark>/g), null);
+                done();
+            }
+        );
+    });
+
 });


### PR DESCRIPTION
Continue on empty results as srid and geom type are not critical
when there are no results

Fixes #299