### PR TITLE
Batch queue leader

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -210,7 +210,10 @@ function App() {
     var isBatchProcess = process.argv.indexOf('--no-batch') === -1;
 
     if (global.settings.environment !== 'test' && isBatchProcess) {
-        app.batch = batchFactory(metadataBackend, redisConfig, statsd_client, global.settings.batch_log_filename);
+        var batchName = global.settings.api_hostname || 'batch';
+        app.batch = batchFactory(
+            metadataBackend, redisConfig, batchName, statsd_client, global.settings.batch_log_filename
+        );
         app.batch.start();
     }
 

--- a/batch/batch.js
+++ b/batch/batch.js
@@ -7,8 +7,9 @@ var forever = require('./util/forever');
 var queue = require('queue-async');
 var jobStatus = require('./job_status');
 
-function Batch(jobSubscriber, jobQueuePool, jobRunner, jobService, logger) {
+function Batch(name, jobSubscriber, jobQueuePool, jobRunner, jobService, redisConfig, logger) {
     EventEmitter.call(this);
+    this.name = name || 'batch';
     this.jobSubscriber = jobSubscriber;
     this.jobQueuePool = jobQueuePool;
     this.jobRunner = jobRunner;

--- a/batch/batch.js
+++ b/batch/batch.js
@@ -5,7 +5,6 @@ var EventEmitter = require('events').EventEmitter;
 var debug = require('./util/debug')('batch');
 var forever = require('./util/forever');
 var queue = require('queue-async');
-var jobStatus = require('./job_status');
 
 function Batch(name, jobSubscriber, jobQueuePool, jobRunner, jobService, jobPublisher, redisConfig, logger) {
     EventEmitter.call(this);
@@ -87,11 +86,7 @@ Batch.prototype._consumeJobs = function (host, queue, callback) {
                 return callback(err);
             }
 
-            if (job.data.status === jobStatus.FAILED) {
-                debug('Job %s %s in %s due to: %s', job_id, job.data.status, host, job.failed_reason);
-            } else {
-                debug('Job %s %s in %s', job_id, job.data.status, host);
-            }
+            debug('Job[%s] status=%s in host=%s (error=%s)', job_id, job.data.status, host, job.failed_reason);
 
             self.logger.log(job);
 

--- a/batch/batch.js
+++ b/batch/batch.js
@@ -5,6 +5,7 @@ var EventEmitter = require('events').EventEmitter;
 var debug = require('./util/debug')('batch');
 var forever = require('./util/forever');
 var queue = require('queue-async');
+var Locker = require('./leader/locker');
 
 function Batch(name, jobSubscriber, jobQueuePool, jobRunner, jobService, jobPublisher, redisConfig, logger) {
     EventEmitter.call(this);
@@ -15,6 +16,7 @@ function Batch(name, jobSubscriber, jobQueuePool, jobRunner, jobService, jobPubl
     this.jobService = jobService;
     this.jobPublisher = jobPublisher;
     this.logger = logger;
+    this.locker = Locker.create('redis-distlock', { redisConfig: redisConfig });
 }
 util.inherits(Batch, EventEmitter);
 
@@ -28,25 +30,33 @@ Batch.prototype._subscribe = function () {
     var self = this;
 
     this.jobSubscriber.subscribe(function onMessage(channel, host) {
-        var queue = self.jobQueuePool.getQueue(host);
-
-        // there is nothing to do. It is already running jobs
-        if (queue) {
-            return;
-        }
-        queue = self.jobQueuePool.createQueue(host);
-
-        // do forever, it does not throw a stack overflow
-        forever(function (next) {
-            self._consumeJobs(host, queue, next);
-        }, function (err) {
-            self.jobQueuePool.removeQueue(host);
-
-            if (err.name === 'EmptyQueue') {
-                return debug(err.message);
+        self.locker.lock(host, 5000, function(err) {
+            if (err) {
+                debug('On message could not lock host=%s from %s. Reason: %s', host, self.name, err.message);
+                return;
             }
 
-            debug(err);
+            debug('On message locked host=%s from %s', host, self.name);
+            var queue = self.jobQueuePool.getQueue(host);
+
+            // there is nothing to do. It is already running jobs
+            if (queue) {
+                return;
+            }
+            queue = self.jobQueuePool.createQueue(host);
+
+            // do forever, it does not throw a stack overflow
+            forever(function (next) {
+                self._consumeJobs(host, queue, next);
+            }, function (err) {
+                self.jobQueuePool.removeQueue(host);
+
+                if (err.name === 'EmptyQueue') {
+                    return debug(err.message);
+                }
+
+                debug(err);
+            });
         });
     }, function (err) {
         if (err) {
@@ -60,39 +70,69 @@ Batch.prototype._subscribe = function () {
 
 Batch.prototype._consumeJobs = function (host, queue, callback) {
     var self = this;
-
-    queue.dequeue(host, function (err, job_id) {
+    this.locker.lock(host, 5000, function(err) {
+        // we didn't get the lock for the host
         if (err) {
-            return callback(err);
+            debug('On de-queue could not lock host=%s from %s. Reason: %s', host, self.name, err.message);
+            // In case we have lost the lock but there are pending jobs we re-announce the host
+            self.jobPublisher.publish(host);
+            return callback(new Error('Could not acquire lock for host=' + host));
         }
 
-        if (!job_id) {
-            var emptyQueueError = new Error('Queue ' + host + ' is empty');
-            emptyQueueError.name = 'EmptyQueue';
-            return callback(emptyQueueError);
-        }
+        debug('On de-queue locked host=%s from %s', host, self.name);
 
-        self.jobQueuePool.setCurrentJobId(host, job_id);
+        var lockRenewalIntervalId = setInterval(function() {
+            debug('Trying to extend lock host=%s', host);
+            self.locker.lock(host, 5000, function(err, _lock) {
+                if (err) {
+                    clearInterval(lockRenewalIntervalId);
+                    return callback(err);
+                }
+                if (!err && _lock) {
+                    debug('Extended lock host=%s', host);
+                }
+            });
+        }, 1000);
 
-        self.jobRunner.run(job_id, function (err, job) {
-            self.jobQueuePool.removeCurrentJobId(host);
-
-            if (err && err.name === 'JobNotRunnable') {
-                debug(err.message);
-                return callback();
-            }
-
+        queue.dequeue(host, function (err, job_id) {
             if (err) {
                 return callback(err);
             }
 
-            debug('Job[%s] status=%s in host=%s (error=%s)', job_id, job.data.status, host, job.failed_reason);
+            if (!job_id) {
+                clearInterval(lockRenewalIntervalId);
+                return self.locker.unlock(host, function() {
+                    var emptyQueueError = new Error('Queue ' + host + ' is empty');
+                    emptyQueueError.name = 'EmptyQueue';
+                    return callback(emptyQueueError);
+                });
+            }
 
-            self.logger.log(job);
+            self.jobQueuePool.setCurrentJobId(host, job_id);
 
-            self.emit('job:' + job.data.status, job_id);
+            self.jobRunner.run(job_id, function (err, job) {
+                self.jobQueuePool.removeCurrentJobId(host);
 
-            callback();
+                if (err && err.name === 'JobNotRunnable') {
+                    debug(err.message);
+                    clearInterval(lockRenewalIntervalId);
+                    return callback();
+                }
+
+                if (err) {
+                    clearInterval(lockRenewalIntervalId);
+                    return callback(err);
+                }
+
+                debug('Job[%s] status=%s in host=%s (error=%s)', job_id, job.data.status, host, job.failed_reason);
+
+                self.logger.log(job);
+
+                self.emit('job:' + job.data.status, job_id);
+
+                clearInterval(lockRenewalIntervalId);
+                callback();
+            });
         });
     });
 };

--- a/batch/batch.js
+++ b/batch/batch.js
@@ -7,13 +7,14 @@ var forever = require('./util/forever');
 var queue = require('queue-async');
 var jobStatus = require('./job_status');
 
-function Batch(name, jobSubscriber, jobQueuePool, jobRunner, jobService, redisConfig, logger) {
+function Batch(name, jobSubscriber, jobQueuePool, jobRunner, jobService, jobPublisher, redisConfig, logger) {
     EventEmitter.call(this);
     this.name = name || 'batch';
     this.jobSubscriber = jobSubscriber;
     this.jobQueuePool = jobQueuePool;
     this.jobRunner = jobRunner;
     this.jobService = jobService;
+    this.jobPublisher = jobPublisher;
     this.logger = logger;
 }
 util.inherits(Batch, EventEmitter);

--- a/batch/index.js
+++ b/batch/index.js
@@ -16,7 +16,7 @@ var JobService = require('./job_service');
 var BatchLogger = require('./batch-logger');
 var Batch = require('./batch');
 
-module.exports = function batchFactory (metadataBackend, redisConfig, statsdClient, loggerPath) {
+module.exports = function batchFactory (metadataBackend, redisConfig, name, statsdClient, loggerPath) {
     var redisPoolSubscriber = new RedisPool(_.extend(redisConfig, { name: 'batch-subscriber'}));
     var redisPoolPublisher = new RedisPool(_.extend(redisConfig, { name: 'batch-publisher'}));
     var queueSeeker = new QueueSeeker(metadataBackend);
@@ -32,5 +32,13 @@ module.exports = function batchFactory (metadataBackend, redisConfig, statsdClie
     var jobRunner = new JobRunner(jobService, jobQueue, queryRunner, statsdClient);
     var logger = new BatchLogger(loggerPath);
 
-    return new Batch(jobSubscriber, jobQueuePool, jobRunner, jobService, logger);
+    return new Batch(
+        name,
+        jobSubscriber,
+        jobQueuePool,
+        jobRunner,
+        jobService,
+        redisConfig,
+        logger
+    );
 };

--- a/batch/index.js
+++ b/batch/index.js
@@ -38,6 +38,7 @@ module.exports = function batchFactory (metadataBackend, redisConfig, name, stat
         jobQueuePool,
         jobRunner,
         jobService,
+        jobPublisher,
         redisConfig,
         logger
     );

--- a/batch/leader/locker.js
+++ b/batch/leader/locker.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var _ = require('underscore');
+var RedisPool = require('redis-mpool');
+var RedisDistlockLocker = require('./provider/redis-distlock');
+var debug = require('../util/debug')('leader-locker');
+
+function Locker(locker) {
+    this.locker = locker;
+}
+
+module.exports = Locker;
+
+Locker.prototype.lock = function(host, ttl, callback) {
+    debug('Locker.lock(%s, %d)', host, ttl);
+    this.locker.lock(host, ttl, callback);
+};
+
+Locker.prototype.unlock = function(host, callback) {
+    debug('Locker.unlock(%s)', host);
+    this.locker.unlock(host, callback);
+};
+
+module.exports.create = function createLocker(type, config) {
+    if (type !== 'redis-distlock') {
+        throw new Error('Invalid type Locker type. Valid types are: "redis-distlock"');
+    }
+    var redisPool = new RedisPool(_.extend({ name: 'batch-distlock' }, config.redisConfig));
+    var locker = new RedisDistlockLocker(redisPool);
+    return new Locker(locker);
+};

--- a/batch/leader/provider/redis-distlock.js
+++ b/batch/leader/provider/redis-distlock.js
@@ -1,0 +1,88 @@
+'use strict';
+
+var REDIS_DISTLOCK = {
+    DB: 5,
+    PREFIX: 'batch:locks:'
+};
+
+var Redlock = require('redlock');
+var debug = require('../../util/debug')('redis-distlock');
+
+function RedisDistlockLocker(redisPool) {
+    this.pool = redisPool;
+    this.redlock = null;
+    this._locks = {};
+}
+
+module.exports = RedisDistlockLocker;
+module.exports.type = 'redis-distlock';
+
+function resourceId(host) {
+    return REDIS_DISTLOCK.PREFIX + host;
+}
+
+RedisDistlockLocker.prototype.lock = function(host, ttl, callback) {
+    var self = this;
+    debug('RedisDistlockLocker.lock(%s, %d)', host, ttl);
+    var resource = resourceId(host);
+
+    var lock = this._getLock(resource);
+    function acquireCallback(err, _lock) {
+        if (err) {
+            return callback(err);
+        }
+        self._setLock(resource, _lock);
+        return callback(null, _lock);
+    }
+    if (lock) {
+        return this._tryExtend(lock, ttl, function(err, _lock) {
+            if (err) {
+                return self._tryAcquire(resource, ttl, acquireCallback);
+            }
+
+            return callback(null, _lock);
+        });
+    } else {
+        return this._tryAcquire(resource, ttl, acquireCallback);
+    }
+};
+
+RedisDistlockLocker.prototype.unlock = function(host, callback) {
+    var lock = this._getLock(resourceId(host));
+    if (lock && this.redlock) {
+        return this.redlock.unlock(lock, callback);
+    }
+};
+
+RedisDistlockLocker.prototype._getLock = function(resource) {
+    if (this._locks.hasOwnProperty(resource)) {
+        return this._locks[resource];
+    }
+    return null;
+};
+
+RedisDistlockLocker.prototype._setLock = function(resource, lock) {
+    this._locks[resource] = lock;
+};
+
+RedisDistlockLocker.prototype._tryExtend = function(lock, ttl, callback) {
+    return lock.extend(ttl, function(err, _lock) {
+        return callback(err, _lock);
+    });
+};
+
+RedisDistlockLocker.prototype._tryAcquire = function(resource, ttl, callback) {
+    var self = this;
+    this.pool.acquire(REDIS_DISTLOCK.DB, function (err, client) {
+        self.redlock = new Redlock([client], {
+            // see http://redis.io/topics/distlock
+            driftFactor: 0.01, // time in ms
+            // the max number of times Redlock will attempt to lock a resource before failing
+            retryCount: 3,
+            // the time in ms between attempts
+            retryDelay: 200
+        });
+
+        self.redlock.lock(resource, ttl, callback);
+    });
+};

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -192,7 +192,7 @@
           "dependencies": {
             "mime-types": {
               "version": "2.1.12",
-              "from": "mime-types@>=2.1.11 <2.2.0",
+              "from": "mime-types@>=2.1.6 <2.2.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
               "dependencies": {
                 "mime-db": {
@@ -422,7 +422,7 @@
             },
             "mime-types": {
               "version": "2.1.12",
-              "from": "mime-types@>=2.1.11 <2.2.0",
+              "from": "mime-types@>=2.1.6 <2.2.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
               "dependencies": {
                 "mime-db": {
@@ -646,7 +646,7 @@
             },
             "mime-types": {
               "version": "2.1.12",
-              "from": "mime-types@>=2.1.2 <2.2.0",
+              "from": "mime-types@>=2.1.11 <2.2.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
               "dependencies": {
                 "mime-db": {
@@ -728,6 +728,18 @@
               "resolved": "https://registry.npmjs.org/nan/-/nan-1.1.2.tgz"
             }
           }
+        }
+      }
+    },
+    "redlock": {
+      "version": "2.0.1",
+      "from": "redlock@2.0.1",
+      "resolved": "https://registry.npmjs.org/redlock/-/redlock-2.0.1.tgz",
+      "dependencies": {
+        "bluebird": {
+          "version": "3.4.6",
+          "from": "bluebird@>=3.3.3 <4.0.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz"
         }
       }
     },
@@ -967,9 +979,9 @@
                           }
                         },
                         "spdx-expression-parse": {
-                          "version": "1.0.3",
+                          "version": "1.0.4",
                           "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.3.tgz"
+                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
                         }
                       }
                     }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "qs": "~6.2.1",
     "queue-async": "~1.0.7",
     "redis-mpool": "0.4.0",
+    "redlock": "2.0.1",
     "step": "~0.0.5",
     "step-profiler": "~0.3.0",
     "topojson": "0.0.8",

--- a/test/acceptance/batch/job.query.order.test.js
+++ b/test/acceptance/batch/job.query.order.test.js
@@ -1,7 +1,7 @@
 require('../../helper');
 var assert = require('../../support/assert');
 
-var BatchTestClient = require('./batch-test-client');
+var BatchTestClient = require('../../support/batch-test-client');
 var JobStatus = require('../../../batch/job_status');
 
 describe('job query order', function() {

--- a/test/acceptance/batch/job.query.order.test.js
+++ b/test/acceptance/batch/job.query.order.test.js
@@ -20,7 +20,7 @@ describe('job query order', function() {
         };
     }
 
-    it('should run query with higher user timeout', function (done) {
+    it('should run job queries in order (single consumer)', function (done) {
         var jobRequest1 = createJob(["select 1", "select 2"]);
         var jobRequest2 = createJob(["select 3"]);
 

--- a/test/acceptance/batch/job.query.timeout.test.js
+++ b/test/acceptance/batch/job.query.timeout.test.js
@@ -1,7 +1,7 @@
 require('../../helper');
 var assert = require('../../support/assert');
 
-var BatchTestClient = require('./batch-test-client');
+var BatchTestClient = require('../../support/batch-test-client');
 var JobStatus = require('../../../batch/job_status');
 
 describe('job query timeout', function() {

--- a/test/acceptance/batch/leader.job.query.order.test.js
+++ b/test/acceptance/batch/leader.job.query.order.test.js
@@ -35,8 +35,14 @@ describe('multiple batch clients job query order', function() {
     }
 
     it('should run job queries in order (multiple consumers)', function (done) {
-        var jobRequest1 = createJob(["insert into ordered_inserts values(1)", "insert into ordered_inserts values(2)"]);
-        var jobRequest2 = createJob(["insert into ordered_inserts values(3)"]);
+        var jobRequest1 = createJob([
+            "insert into ordered_inserts values(1)",
+            "select pg_sleep(1)",
+            "insert into ordered_inserts values(2)"
+        ]);
+        var jobRequest2 = createJob([
+            "insert into ordered_inserts values(3)"
+        ]);
 
         var self = this;
 

--- a/test/acceptance/batch/leader.job.query.order.test.js
+++ b/test/acceptance/batch/leader.job.query.order.test.js
@@ -12,7 +12,10 @@ describe('multiple batch clients job query order', function() {
         this.batchTestClient2 = new BatchTestClient({ name: 'consumerB' });
 
         this.testClient = new TestClient();
-        this.testClient.getResult('create table ordered_inserts (status numeric)', done);
+        this.testClient.getResult(
+            'drop table if exists ordered_inserts; create table ordered_inserts (status numeric)',
+            done
+        );
     });
 
     after(function (done) {
@@ -21,13 +24,7 @@ describe('multiple batch clients job query order', function() {
                 return done(err);
             }
 
-            this.batchTestClient2.drain(function(err) {
-                if (err) {
-                    return done(err);
-                }
-
-                this.testClient.getResult('drop table ordered_inserts', done);
-            }.bind(this));
+            this.batchTestClient2.drain(done);
         }.bind(this));
     });
 

--- a/test/acceptance/batch/leader.job.query.order.test.js
+++ b/test/acceptance/batch/leader.job.query.order.test.js
@@ -8,8 +8,8 @@ var JobStatus = require('../../../batch/job_status');
 describe('multiple batch clients job query order', function() {
 
     before(function(done) {
-        this.batchTestClient1 = new BatchTestClient();
-        this.batchTestClient2 = new BatchTestClient();
+        this.batchTestClient1 = new BatchTestClient({ name: 'consumerA' });
+        this.batchTestClient2 = new BatchTestClient({ name: 'consumerB' });
 
         this.testClient = new TestClient();
         this.testClient.getResult('create table ordered_inserts (status numeric)', done);

--- a/test/acceptance/batch/leader.job.query.order.test.js
+++ b/test/acceptance/batch/leader.job.query.order.test.js
@@ -1,0 +1,83 @@
+require('../../helper');
+var assert = require('../../support/assert');
+
+var TestClient = require('../../support/test-client');
+var BatchTestClient = require('../../support/batch-test-client');
+var JobStatus = require('../../../batch/job_status');
+
+describe('multiple batch clients job query order', function() {
+
+    before(function(done) {
+        this.batchTestClient1 = new BatchTestClient();
+        this.batchTestClient2 = new BatchTestClient();
+
+        this.testClient = new TestClient();
+        this.testClient.getResult('create table ordered_inserts (status numeric)', done);
+    });
+
+    after(function (done) {
+        this.batchTestClient1.drain(function(err) {
+            if (err) {
+                return done(err);
+            }
+
+            this.batchTestClient2.drain(function(err) {
+                if (err) {
+                    return done(err);
+                }
+
+                this.testClient.getResult('drop table ordered_inserts', done);
+            }.bind(this));
+        }.bind(this));
+    });
+
+    function createJob(queries) {
+        return {
+            query: queries
+        };
+    }
+
+    it('should run job queries in order (multiple consumers)', function (done) {
+        var jobRequest1 = createJob(["insert into ordered_inserts values(1)", "insert into ordered_inserts values(2)"]);
+        var jobRequest2 = createJob(["insert into ordered_inserts values(3)"]);
+
+        var self = this;
+
+        this.batchTestClient1.createJob(jobRequest1, function(err, jobResult1) {
+            if (err) {
+                return done(err);
+            }
+            this.batchTestClient2.createJob(jobRequest2, function(err, jobResult2) {
+                if (err) {
+                    return done(err);
+                }
+
+                jobResult1.getStatus(function (err, job1) {
+                    if (err) {
+                        return done(err);
+                    }
+                    jobResult2.getStatus(function(err, job2) {
+                        if (err) {
+                            return done(err);
+                        }
+                        assert.equal(job1.status, JobStatus.DONE);
+                        assert.equal(job2.status, JobStatus.DONE);
+
+                        self.testClient.getResult('select * from ordered_inserts', function(err, rows) {
+                            assert.ok(!err);
+
+                            assert.deepEqual(rows, [{ status: 1 }, { status: 2 }, { status: 3 }]);
+                            assert.ok(
+                                new Date(job1.updated_at).getTime() < new Date(job2.updated_at).getTime(),
+                                'job1 (' + job1.updated_at + ') should finish before job2 (' + job2.updated_at + ')'
+                            );
+                            done();
+                        });
+
+                    });
+                });
+            });
+        }.bind(this));
+    });
+
+});

--- a/test/support/batch-test-client.js
+++ b/test/support/batch-test-client.js
@@ -26,7 +26,7 @@ function BatchTestClient(config) {
     this.config = config || {};
     this.server = appServer();
 
-    this.batch = batchFactory(metadataBackend, redisUtils.getConfig());
+    this.batch = batchFactory(metadataBackend, redisUtils.getConfig(), this.config.name);
     this.batch.start();
 
     this.pendingJobs = [];

--- a/test/support/batch-test-client.js
+++ b/test/support/batch-test-client.js
@@ -1,14 +1,14 @@
 'use strict';
 
-require('../../helper');
-var assert = require('../../support/assert');
-var appServer = require('../../../app/server');
-var redisUtils = require('../../support/redis_utils');
+require('../helper');
+var assert = require('assert');
+var appServer = require('../../app/server');
+var redisUtils = require('./redis_utils');
 var debug = require('debug')('batch-test-client');
 
-var JobStatus = require('../../../batch/job_status');
+var JobStatus = require('../../batch/job_status');
 var metadataBackend = require('cartodb-redis')(redisUtils.getConfig());
-var batchFactory = require('../../../batch/index');
+var batchFactory = require('../../batch/index');
 
 function response(code) {
     return {

--- a/test/support/test-client.js
+++ b/test/support/test-client.js
@@ -1,0 +1,59 @@
+'use strict';
+
+require('../helper');
+var assert = require('assert');
+var appServer = require('../../app/server');
+
+function response(code) {
+    return {
+        status: code
+    };
+}
+
+var RESPONSE = {
+    OK: response(200),
+    CREATED: response(201)
+};
+
+
+function TestClient(config) {
+    this.config = config || {};
+    this.server = appServer();
+}
+
+module.exports = TestClient;
+
+
+TestClient.prototype.getResult = function(query, callback) {
+    assert.response(
+        this.server,
+        {
+            url: this.getUrl(),
+            headers: {
+                host: this.getHost(),
+                'Content-Type': 'application/json'
+            },
+            method: 'POST',
+            data: JSON.stringify({
+                q: query
+            })
+        },
+        RESPONSE.OK,
+        function (err, res) {
+            if (err) {
+                return callback(err);
+            }
+            var result = JSON.parse(res.body);
+
+            return callback(null, result.rows || []);
+        }
+    );
+};
+
+TestClient.prototype.getHost = function() {
+    return this.config.host || 'vizzuality.cartodb.com';
+};
+
+TestClient.prototype.getUrl = function() {
+    return '/api/v2/sql?api_key=' + (this.config.apiKey || '1234');
+};


### PR DESCRIPTION
Add distributed lock to run all jobs by ordered and grouped by host name.

It uses http://redis.io/topics/distlock, which is not perfect: http://martin.kleppmann.com/2016/02/08/how-to-do-distributed-locking.html.