### PR TITLE
Moves from host queues to user queues

### DIFF
--- a/batch/batch.js
+++ b/batch/batch.js
@@ -6,6 +6,7 @@ var debug = require('./util/debug')('batch');
 var forever = require('./util/forever');
 var queue = require('queue-async');
 var Locker = require('./leader/locker');
+var HostUserQueueMover = require('./maintenance/host-user-queue-mover');
 
 function Batch(name, jobSubscriber, jobQueue, jobRunner, jobService, jobPublisher, redisConfig, logger) {
     EventEmitter.call(this);
@@ -17,6 +18,7 @@ function Batch(name, jobSubscriber, jobQueue, jobRunner, jobService, jobPublishe
     this.jobPublisher = jobPublisher;
     this.logger = logger;
     this.locker = Locker.create('redis-distlock', { redisConfig: redisConfig });
+    this.hostUserQueueMover = new HostUserQueueMover(jobQueue, jobService, this.locker, redisConfig);
 
     // map: host => jobId
     this.workingQueues = {};
@@ -26,12 +28,19 @@ util.inherits(Batch, EventEmitter);
 module.exports = Batch;
 
 Batch.prototype.start = function () {
+    this.hostUserQueueMover.moveOldJobs(function() {
+        this.subscribe();
+    }.bind(this));
+};
+
+Batch.prototype.subscribe = function () {
     var self = this;
 
     this.jobSubscriber.subscribe(
-        function onJobHandler(host) {
-            if (self.isProcessingHost(host)) {
-                return debug('%s is already processing host=%s', self.name, host);
+        function onJobHandler(user, host) {
+            debug('onJobHandler(%s, %s)', user, host);
+            if (self.isProcessingUser(user)) {
+                return debug('%s is already processing user=%s', self.name, user);
             }
 
             // do forever, it does not throw a stack overflow
@@ -40,11 +49,14 @@ Batch.prototype.start = function () {
                     self.locker.lock(host, function(err) {
                         // we didn't get the lock for the host
                         if (err) {
-                            debug('Could not lock host=%s from %s. Reason: %s', host, self.name, err.message);
+                            debug(
+                                'Could not lock host=%s for user=%s from %s. Reason: %s',
+                                host, self.name, user, err.message
+                            );
                             return next(err);
                         }
-                        debug('Locked host=%s from %s', host, self.name);
-                        self.processNextJob(host, next);
+                        debug('Locked host=%s for user=%s from %s', host, user, self.name);
+                        self.processNextJob(user, next);
                     });
                 },
                 function (err) {
@@ -52,7 +64,7 @@ Batch.prototype.start = function () {
                         debug(err.name === 'EmptyQueue' ? err.message : err);
                     }
 
-                    self.finishedProcessingHost(host);
+                    self.finishedProcessingUser(user);
                     self.locker.unlock(host, debug);
                 }
             );
@@ -67,23 +79,27 @@ Batch.prototype.start = function () {
     );
 };
 
-Batch.prototype.processNextJob = function (host, callback) {
+Batch.prototype.processNextJob = function (user, callback) {
+    // This is missing the logic for processing several users within the same host
+    // It requires to:
+    //  - Take care of number of jobs running at the same time per host.
+    //  - Execute user jobs in order.
     var self = this;
-    self.jobQueue.dequeue(host, function (err, jobId) {
+    self.jobQueue.dequeue(user, function (err, jobId) {
         if (err) {
             return callback(err);
         }
 
         if (!jobId) {
-            var emptyQueueError = new Error('Queue ' + host + ' is empty');
+            var emptyQueueError = new Error('Queue for user="' + user + '" is empty');
             emptyQueueError.name = 'EmptyQueue';
             return callback(emptyQueueError);
         }
 
-        self.setProcessingJobId(host, jobId);
+        self.setProcessingJobId(user, jobId);
 
         self.jobRunner.run(jobId, function (err, job) {
-            self.setProcessingJobId(host, null);
+            self.setProcessingJobId(user, null);
 
             if (err) {
                 debug(err);
@@ -93,7 +109,7 @@ Batch.prototype.processNextJob = function (host, callback) {
                 return callback(err);
             }
 
-            debug('Job[%s] status=%s in host=%s (failed_reason=%s)', jobId, job.data.status, host, job.failed_reason);
+            debug('Job=%s status=%s user=%s (failed_reason=%s)', jobId, job.data.status, user, job.failed_reason);
 
             self.logger.log(job);
 
@@ -106,11 +122,11 @@ Batch.prototype.processNextJob = function (host, callback) {
 
 Batch.prototype.drain = function (callback) {
     var self = this;
-    var workingHosts = this.getWorkingHosts();
-    var batchQueues = queue(workingHosts.length);
+    var workingUsers = this.getWorkingUsers();
+    var batchQueues = queue(workingUsers.length);
 
-    workingHosts.forEach(function (host) {
-        batchQueues.defer(self._drainJob.bind(self), host);
+    workingUsers.forEach(function (user) {
+        batchQueues.defer(self._drainJob.bind(self), user);
     });
 
     batchQueues.awaitAll(function (err) {
@@ -124,9 +140,9 @@ Batch.prototype.drain = function (callback) {
     });
 };
 
-Batch.prototype._drainJob = function (host, callback) {
+Batch.prototype._drainJob = function (user, callback) {
     var self = this;
-    var job_id = this.getProcessingJobId(host);
+    var job_id = this.getProcessingJobId(user);
 
     if (!job_id) {
         return process.nextTick(function () {
@@ -143,7 +159,7 @@ Batch.prototype._drainJob = function (host, callback) {
             return callback(err);
         }
 
-        self.jobQueue.enqueueFirst(job_id, host, callback);
+        self.jobQueue.enqueueFirst(user, job_id, callback);
     });
 };
 
@@ -152,22 +168,22 @@ Batch.prototype.stop = function (callback) {
     this.jobSubscriber.unsubscribe(callback);
 };
 
-Batch.prototype.isProcessingHost = function(host) {
-    return this.workingQueues.hasOwnProperty(host);
+Batch.prototype.isProcessingUser = function(user) {
+    return this.workingQueues.hasOwnProperty(user);
 };
 
-Batch.prototype.getWorkingHosts = function() {
+Batch.prototype.getWorkingUsers = function() {
     return Object.keys(this.workingQueues);
 };
 
-Batch.prototype.setProcessingJobId = function(host, jobId) {
-    this.workingQueues[host] = jobId;
+Batch.prototype.setProcessingJobId = function(user, jobId) {
+    this.workingQueues[user] = jobId;
 };
 
-Batch.prototype.getProcessingJobId = function(host) {
-    return this.workingQueues[host];
+Batch.prototype.getProcessingJobId = function(user) {
+    return this.workingQueues[user];
 };
 
-Batch.prototype.finishedProcessingHost = function(host) {
-    delete this.workingQueues[host];
+Batch.prototype.finishedProcessingUser = function(user) {
+    delete this.workingQueues[user];
 };

--- a/batch/batch.js
+++ b/batch/batch.js
@@ -38,6 +38,7 @@ Batch.prototype.subscribe = function () {
 
     this.jobSubscriber.subscribe(
         function onJobHandler(user, host) {
+            var resource = host + ':' + user;
             debug('onJobHandler(%s, %s)', user, host);
             if (self.isProcessingUser(user)) {
                 return debug('%s is already processing user=%s', self.name, user);
@@ -46,7 +47,7 @@ Batch.prototype.subscribe = function () {
             // do forever, it does not throw a stack overflow
             forever(
                 function (next) {
-                    self.locker.lock(host, function(err) {
+                    self.locker.lock(resource, function(err) {
                         // we didn't get the lock for the host
                         if (err) {
                             debug(
@@ -65,7 +66,7 @@ Batch.prototype.subscribe = function () {
                     }
 
                     self.finishedProcessingUser(user);
-                    self.locker.unlock(host, debug);
+                    self.locker.unlock(resource, debug);
                 }
             );
         },

--- a/batch/index.js
+++ b/batch/index.js
@@ -15,13 +15,14 @@ var BatchLogger = require('./batch-logger');
 var Batch = require('./batch');
 
 module.exports = function batchFactory (metadataBackend, redisConfig, name, statsdClient, loggerPath) {
+    var userDatabaseMetadataService = new UserDatabaseMetadataService(metadataBackend);
+
     var pubSubRedisPool = new RedisPool(_.extend({ name: 'batch-pubsub'}, redisConfig));
-    var jobSubscriber = new JobSubscriber(pubSubRedisPool);
+    var jobSubscriber = new JobSubscriber(pubSubRedisPool, userDatabaseMetadataService);
     var jobPublisher = new JobPublisher(pubSubRedisPool);
 
     var jobQueue =  new JobQueue(metadataBackend, jobPublisher);
     var jobBackend = new JobBackend(metadataBackend, jobQueue);
-    var userDatabaseMetadataService = new UserDatabaseMetadataService(metadataBackend);
     var queryRunner = new QueryRunner(userDatabaseMetadataService);
     var jobCanceller = new JobCanceller(userDatabaseMetadataService);
     var jobService = new JobService(jobBackend, jobCanceller);

--- a/batch/job_backend.js
+++ b/batch/job_backend.js
@@ -7,7 +7,7 @@ var JobStatus = require('./job_status');
 function JobBackend(metadataBackend, jobQueue) {
     this.metadataBackend = metadataBackend;
     this.jobQueue = jobQueue;
-    this.maxNumberOfQueuedJobs = global.settings.batch_max_queued_jobs || 100;
+    this.maxNumberOfQueuedJobs = global.settings.batch_max_queued_jobs || 250;
     this.inSecondsJobTTLAfterFinished = global.settings.finished_jobs_ttl_in_seconds || 2 * 3600; // 2 hours
 }
 

--- a/batch/job_backend.js
+++ b/batch/job_backend.js
@@ -2,13 +2,13 @@
 
 var REDIS_PREFIX = 'batch:jobs:';
 var REDIS_DB = 5;
-var FINISHED_JOBS_TTL_IN_SECONDS = global.settings.finished_jobs_ttl_in_seconds || 2 * 3600; // 2 hours
 var JobStatus = require('./job_status');
 
 function JobBackend(metadataBackend, jobQueue) {
     this.metadataBackend = metadataBackend;
     this.jobQueue = jobQueue;
     this.maxNumberOfQueuedJobs = global.settings.batch_max_queued_jobs || 100;
+    this.inSecondsJobTTLAfterFinished = global.settings.finished_jobs_ttl_in_seconds || 2 * 3600; // 2 hours
 }
 
 function toRedisParams(job) {
@@ -169,7 +169,7 @@ JobBackend.prototype.setTTL = function (job, callback) {
         return callback();
     }
 
-    self.metadataBackend.redisCmd(REDIS_DB, 'EXPIRE', [ redisKey, FINISHED_JOBS_TTL_IN_SECONDS ], callback);
+    self.metadataBackend.redisCmd(REDIS_DB, 'EXPIRE', [ redisKey, this.inSecondsJobTTLAfterFinished ], callback);
 };
 
 module.exports = JobBackend;

--- a/batch/job_backend.js
+++ b/batch/job_backend.js
@@ -101,7 +101,7 @@ JobBackend.prototype.create = function (job, callback) {
                 return callback(err);
             }
 
-            self.jobQueueProducer.enqueue(job.job_id, job.host, function (err) {
+            self.jobQueueProducer.enqueue(job.user, job.job_id, function (err) {
                 if (err) {
                     return callback(err);
                 }

--- a/batch/job_queue.js
+++ b/batch/job_queue.js
@@ -9,27 +9,27 @@ module.exports = JobQueue;
 
 var QUEUE = {
     DB: 5,
-    PREFIX: 'batch:queues:'
+    PREFIX: 'batch:queue:'
 };
 module.exports.QUEUE = QUEUE;
 
-JobQueue.prototype.enqueue = function (job_id, host, callback) {
+JobQueue.prototype.enqueue = function (user, jobId, callback) {
     var self = this;
 
-    this.metadataBackend.redisCmd(QUEUE.DB, 'LPUSH', [ QUEUE.PREFIX + host, job_id ], function (err) {
+    this.metadataBackend.redisCmd(QUEUE.DB, 'LPUSH', [ QUEUE.PREFIX + user, jobId ], function (err) {
         if (err) {
             return callback(err);
         }
 
-        self.jobPublisher.publish(host);
+        self.jobPublisher.publish(user);
         callback();
     });
 };
 
-JobQueue.prototype.dequeue = function (host, callback) {
-    this.metadataBackend.redisCmd(QUEUE.DB, 'RPOP', [ QUEUE.PREFIX + host ], callback);
+JobQueue.prototype.dequeue = function (user, callback) {
+    this.metadataBackend.redisCmd(QUEUE.DB, 'RPOP', [ QUEUE.PREFIX + user ], callback);
 };
 
-JobQueue.prototype.enqueueFirst = function (job_id, host, callback) {
-    this.metadataBackend.redisCmd(QUEUE.DB, 'RPUSH', [ QUEUE.PREFIX + host, job_id ], callback);
+JobQueue.prototype.enqueueFirst = function (user, jobId, callback) {
+    this.metadataBackend.redisCmd(QUEUE.DB, 'RPUSH', [ QUEUE.PREFIX + user, jobId ], callback);
 };

--- a/batch/job_queue.js
+++ b/batch/job_queue.js
@@ -26,6 +26,10 @@ JobQueue.prototype.enqueue = function (user, jobId, callback) {
     });
 };
 
+JobQueue.prototype.size = function (user, callback) {
+    this.metadataBackend.redisCmd(QUEUE.DB, 'LLEN', [ QUEUE.PREFIX + user ], callback);
+};
+
 JobQueue.prototype.dequeue = function (user, callback) {
     this.metadataBackend.redisCmd(QUEUE.DB, 'RPOP', [ QUEUE.PREFIX + user ], callback);
 };

--- a/batch/job_runner.js
+++ b/batch/job_runner.js
@@ -93,7 +93,7 @@ JobRunner.prototype._run = function (job, query, timeout, profiler, callback) {
                 return callback(null, job);
             }
 
-            self.jobQueue.enqueueFirst(job.data.job_id, job.data.host, function (err) {
+            self.jobQueue.enqueueFirst(job.data.user, job.data.job_id, function (err) {
                 if (err) {
                     return callback(err);
                 }

--- a/batch/leader/locker.js
+++ b/batch/leader/locker.js
@@ -18,47 +18,47 @@ function Locker(locker, ttl) {
 
 module.exports = Locker;
 
-Locker.prototype.lock = function(host, callback) {
+Locker.prototype.lock = function(resource, callback) {
     var self = this;
-    debug('Locker.lock(%s, %d)', host, this.ttl);
-    this.locker.lock(host, this.ttl, function (err, lock) {
+    debug('Locker.lock(%s, %d)', resource, this.ttl);
+    this.locker.lock(resource, this.ttl, function (err, lock) {
         if (!err) {
-            self.startRenewal(host);
+            self.startRenewal(resource);
         }
         return callback(err, lock);
     });
 };
 
-Locker.prototype.unlock = function(host, callback) {
+Locker.prototype.unlock = function(resource, callback) {
     var self = this;
-    debug('Locker.unlock(%s)', host);
-    this.locker.unlock(host, function(err) {
-        self.stopRenewal(host);
+    debug('Locker.unlock(%s)', resource);
+    this.locker.unlock(resource, function(err) {
+        self.stopRenewal(resource);
         return callback(err);
     });
 };
 
-Locker.prototype.startRenewal = function(host) {
+Locker.prototype.startRenewal = function(resource) {
     var self = this;
-    if (!this.intervalIds.hasOwnProperty(host)) {
-        this.intervalIds[host] = setInterval(function() {
-            debug('Trying to extend lock host=%s', host);
-            self.locker.lock(host, self.ttl, function(err, _lock) {
+    if (!this.intervalIds.hasOwnProperty(resource)) {
+        this.intervalIds[resource] = setInterval(function() {
+            debug('Trying to extend lock resource=%s', resource);
+            self.locker.lock(resource, self.ttl, function(err, _lock) {
                 if (err) {
-                    return self.stopRenewal(host);
+                    return self.stopRenewal(resource);
                 }
                 if (_lock) {
-                    debug('Extended lock host=%s', host);
+                    debug('Extended lock resource=%s', resource);
                 }
             });
         }, this.renewInterval);
     }
 };
 
-Locker.prototype.stopRenewal = function(host) {
-    if (this.intervalIds.hasOwnProperty(host)) {
-        clearInterval(this.intervalIds[host]);
-        delete this.intervalIds[host];
+Locker.prototype.stopRenewal = function(resource) {
+    if (this.intervalIds.hasOwnProperty(resource)) {
+        clearInterval(this.intervalIds[resource]);
+        delete this.intervalIds[resource];
     }
 };
 

--- a/batch/leader/provider/redis-distlock.js
+++ b/batch/leader/provider/redis-distlock.js
@@ -24,39 +24,39 @@ function RedisDistlockLocker(redisPool) {
 module.exports = RedisDistlockLocker;
 module.exports.type = 'redis-distlock';
 
-function resourceId(host) {
-    return REDIS_DISTLOCK.PREFIX + host;
+function resourceId(resource) {
+    return REDIS_DISTLOCK.PREFIX + resource;
 }
 
-RedisDistlockLocker.prototype.lock = function(host, ttl, callback) {
+RedisDistlockLocker.prototype.lock = function(resource, ttl, callback) {
     var self = this;
-    debug('RedisDistlockLocker.lock(%s, %d)', host, ttl);
-    var resource = resourceId(host);
+    debug('RedisDistlockLocker.lock(%s, %d)', resource, ttl);
+    var lockId = resourceId(resource);
 
-    var lock = this._getLock(resource);
+    var lock = this._getLock(lockId);
     function acquireCallback(err, _lock) {
         if (err) {
             return callback(err);
         }
-        self._setLock(resource, _lock);
+        self._setLock(lockId, _lock);
         return callback(null, _lock);
     }
     if (lock) {
         return this._tryExtend(lock, ttl, function(err, _lock) {
             if (err) {
-                return self._tryAcquire(resource, ttl, acquireCallback);
+                return self._tryAcquire(lockId, ttl, acquireCallback);
             }
 
             return callback(null, _lock);
         });
     } else {
-        return this._tryAcquire(resource, ttl, acquireCallback);
+        return this._tryAcquire(lockId, ttl, acquireCallback);
     }
 };
 
-RedisDistlockLocker.prototype.unlock = function(host, callback) {
+RedisDistlockLocker.prototype.unlock = function(resource, callback) {
     var self = this;
-    var lock = this._getLock(resourceId(host));
+    var lock = this._getLock(resourceId(resource));
     if (lock) {
         this.pool.acquire(REDIS_DISTLOCK.DB, function (err, client) {
             if (err) {

--- a/batch/maintenance/host-user-queue-mover.js
+++ b/batch/maintenance/host-user-queue-mover.js
@@ -1,0 +1,142 @@
+'use strict';
+
+var RedisPool = require('redis-mpool');
+var _ = require('underscore');
+var asyncQ = require('queue-async');
+var debug = require('../util/debug')('queue-mover');
+var forever = require('../util/forever');
+
+var QUEUE = {
+    OLD: {
+        DB: 5,
+        PREFIX: 'batch:queues:' // host
+    },
+    NEW: {
+        DB: 5,
+        PREFIX: 'batch:queue:' // user
+    }
+};
+
+function HostUserQueueMover(jobQueue, jobService, locker, redisConfig) {
+    this.jobQueue = jobQueue;
+    this.jobService = jobService;
+    this.locker = locker;
+    this.pool = new RedisPool(_.extend({ name: 'batch-distlock' }, redisConfig));
+}
+
+module.exports = HostUserQueueMover;
+
+HostUserQueueMover.prototype.moveOldJobs = function(callback) {
+    var self = this;
+    this.getOldQueues(function(err, hosts) {
+        var async = asyncQ(4);
+        hosts.forEach(function(host) {
+            async.defer(self.moveOldQueueJobs.bind(self), host);
+        });
+
+        async.awaitAll(function (err) {
+            if (err) {
+                debug('Something went wrong moving jobs', err);
+            } else {
+                debug('Finished moving all jobs');
+            }
+
+            callback();
+        });
+    });
+};
+
+HostUserQueueMover.prototype.moveOldQueueJobs = function(host, callback) {
+    var self = this;
+    // do forever, it does not throw a stack overflow
+    forever(
+        function (next) {
+            self.locker.lock(host, function(err) {
+                // we didn't get the lock for the host
+                if (err) {
+                    debug('Could not lock host=%s. Reason: %s', host, err.message);
+                    return next(err);
+                }
+                debug('Locked host=%s', host);
+                self.processNextJob(host, next);
+            });
+        },
+        function (err) {
+            if (err) {
+                debug(err.name === 'EmptyQueue' ? err.message : err);
+            }
+            self.locker.unlock(host, callback);
+        }
+    );
+};
+
+//this.metadataBackend.redisCmd(QUEUE.DB, 'RPOP', [ QUEUE.PREFIX + user ], callback);
+
+HostUserQueueMover.prototype.processNextJob = function (host, callback) {
+    var self = this;
+    this.pool.acquire(QUEUE.OLD.DB, function(err, client) {
+        if (err) {
+            return callback(err);
+        }
+
+        client.lpop(QUEUE.OLD.PREFIX + host, function(err, jobId) {
+            debug('Found jobId=%s at queue=%s', jobId, host);
+            if (!jobId) {
+                var emptyQueueError = new Error('Empty queue');
+                emptyQueueError.name = 'EmptyQueue';
+                return callback(emptyQueueError);
+            }
+            self.pool.release(QUEUE.OLD.DB, client);
+            self.jobService.get(jobId, function(err, job) {
+                if (err) {
+                    debug(err);
+                    return callback();
+                }
+                if (job) {
+                    return self.jobQueue.enqueueFirst(job.data.user, jobId, function() {
+                        return callback();
+                    });
+                }
+                return callback();
+            });
+        });
+    });
+};
+
+HostUserQueueMover.prototype.getOldQueues = function(callback) {
+    var initialCursor = ['0'];
+    var hosts = {};
+    this._getOldQueues(initialCursor, hosts, callback);
+};
+
+HostUserQueueMover.prototype._getOldQueues = function (cursor, hosts, callback) {
+    var self = this;
+    var redisParams = [cursor[0], 'MATCH', QUEUE.OLD.PREFIX + '*'];
+
+    this.pool.acquire(QUEUE.OLD.DB, function(err, client) {
+        if (err) {
+            return callback(err);
+        }
+
+        client.scan(redisParams, function(err, currentCursor) {
+            // checks if iteration has ended
+            if (currentCursor[0] === '0') {
+                self.pool.release(QUEUE.OLD.DB, client);
+                return callback(null, Object.keys(hosts));
+            }
+
+            var queues = currentCursor[1];
+
+            if (!queues) {
+                return callback(null);
+            }
+
+            queues.forEach(function (queue) {
+                var host = queue.substr(QUEUE.OLD.PREFIX.length);
+                hosts[host] = true;
+            });
+
+            self._getOldQueues(currentCursor, hosts, callback);
+        });
+    });
+};

--- a/batch/pubsub/channel.js
+++ b/batch/pubsub/channel.js
@@ -1,4 +1,4 @@
 module.exports = {
     DB: 0,
-    NAME: 'batch:hosts'
+    NAME: 'batch:users'
 };

--- a/batch/pubsub/job-publisher.js
+++ b/batch/pubsub/job-publisher.js
@@ -8,7 +8,7 @@ function JobPublisher(pool) {
     this.pool = pool;
 }
 
-JobPublisher.prototype.publish = function (host) {
+JobPublisher.prototype.publish = function (user) {
     var self = this;
 
     this.pool.acquire(Channel.DB, function (err, client) {
@@ -16,14 +16,14 @@ JobPublisher.prototype.publish = function (host) {
             return error('Error adquiring redis client: ' + err.message);
         }
 
-        client.publish(Channel.NAME, host, function (err) {
+        client.publish(Channel.NAME, user, function (err) {
             self.pool.release(Channel.DB, client);
 
             if (err) {
-                return error('Error publishing to ' + Channel.NAME + ':' + host + ', ' + err.message);
+                return error('Error publishing to ' + Channel.NAME + ':' + user + ', ' + err.message);
             }
 
-            debug('publish to ' + Channel.NAME + ':' + host);
+            debug('publish to ' + Channel.NAME + ':' + user);
         });
     });
 };

--- a/batch/pubsub/queue-seeker.js
+++ b/batch/pubsub/queue-seeker.js
@@ -10,11 +10,11 @@ module.exports = QueueSeeker;
 
 QueueSeeker.prototype.seek = function (callback) {
     var initialCursor = ['0'];
-    var hosts = {};
-    this._seek(initialCursor, hosts, callback);
+    var users = {};
+    this._seek(initialCursor, users, callback);
 };
 
-QueueSeeker.prototype._seek = function (cursor, hosts, callback) {
+QueueSeeker.prototype._seek = function (cursor, users, callback) {
     var self = this;
     var redisParams = [cursor[0], 'MATCH', QUEUE.PREFIX + '*'];
 
@@ -27,7 +27,7 @@ QueueSeeker.prototype._seek = function (cursor, hosts, callback) {
             // checks if iteration has ended
             if (currentCursor[0] === '0') {
                 self.pool.release(QUEUE.DB, client);
-                return callback(null, Object.keys(hosts));
+                return callback(null, Object.keys(users));
             }
 
             var queues = currentCursor[1];
@@ -37,11 +37,11 @@ QueueSeeker.prototype._seek = function (cursor, hosts, callback) {
             }
 
             queues.forEach(function (queue) {
-                var host = queue.substr(QUEUE.PREFIX.length);
-                hosts[host] = true;
+                var user = queue.substr(QUEUE.PREFIX.length);
+                users[user] = true;
             });
 
-            self._seek(currentCursor, hosts, callback);
+            self._seek(currentCursor, users, callback);
         });
     });
 };

--- a/config/environments/development.js.example
+++ b/config/environments/development.js.example
@@ -32,6 +32,8 @@ module.exports.db_batch_port      = '5432';
 module.exports.finished_jobs_ttl_in_seconds = 2 * 3600; // 2 hours
 module.exports.batch_query_timeout = 12 * 3600 * 1000; // 12 hours in milliseconds
 module.exports.batch_log_filename = 'logs/batch-queries.log';
+// Max number of queued jobs a user can have at a given time
+module.exports.batch_max_queued_jobs = 100;
 // Max database connections in the pool
 // Subsequent connections will wait for a free slot.
 // NOTE: not used by OGR-mediated accesses

--- a/config/environments/production.js.example
+++ b/config/environments/production.js.example
@@ -33,6 +33,8 @@ module.exports.db_batch_port      = '5432';
 module.exports.finished_jobs_ttl_in_seconds = 2 * 3600; // 2 hours
 module.exports.batch_query_timeout = 12 * 3600 * 1000; // 12 hours in milliseconds
 module.exports.batch_log_filename = 'logs/batch-queries.log';
+// Max number of queued jobs a user can have at a given time
+module.exports.batch_max_queued_jobs = 100;
 // Max database connections in the pool
 // Subsequent connections will wait for a free slot.i
 // NOTE: not used by OGR-mediated accesses

--- a/config/environments/staging.js.example
+++ b/config/environments/staging.js.example
@@ -33,6 +33,8 @@ module.exports.db_batch_port      = '5432';
 module.exports.finished_jobs_ttl_in_seconds = 2 * 3600; // 2 hours
 module.exports.batch_query_timeout = 12 * 3600 * 1000; // 12 hours in milliseconds
 module.exports.batch_log_filename = 'logs/batch-queries.log';
+// Max number of queued jobs a user can have at a given time
+module.exports.batch_max_queued_jobs = 100;
 // Max database connections in the pool
 // Subsequent connections will wait for a free slot.
 // NOTE: not used by OGR-mediated accesses

--- a/config/environments/test.js.example
+++ b/config/environments/test.js.example
@@ -30,6 +30,8 @@ module.exports.db_batch_port      = '5432';
 module.exports.finished_jobs_ttl_in_seconds = 2 * 3600; // 2 hours
 module.exports.batch_query_timeout = 5 * 1000; // 5 seconds in milliseconds
 module.exports.batch_log_filename = 'logs/batch-queries.log';
+// Max number of queued jobs a user can have at a given time
+module.exports.batch_max_queued_jobs = 100;
 // Max database connections in the pool
 // Subsequent connections will wait for a free slot.
 // NOTE: not used by OGR-mediated accesses

--- a/test/acceptance/batch/leader-multiple-users-query-order.test.js
+++ b/test/acceptance/batch/leader-multiple-users-query-order.test.js
@@ -1,0 +1,110 @@
+require('../../helper');
+var assert = require('../../support/assert');
+
+var TestClient = require('../../support/test-client');
+var BatchTestClient = require('../../support/batch-test-client');
+var JobStatus = require('../../../batch/job_status');
+
+describe('multiple batch clients and users, job query order', function() {
+
+    before(function(done) {
+        this.batchTestClientA = new BatchTestClient({ name: 'consumerA' });
+        this.batchTestClientB = new BatchTestClient({ name: 'consumerB' });
+
+        this.testClientA = new TestClient();
+        this.testClientA.getResult(
+            'drop table if exists ordered_inserts; create table ordered_inserts (status numeric)',
+            done
+        );
+    });
+
+    after(function (done) {
+        this.batchTestClientA.drain(function(err) {
+            if (err) {
+                return done(err);
+            }
+
+            this.batchTestClientB.drain(done);
+        }.bind(this));
+    });
+
+    function createJob(queries) {
+        return {
+            query: queries
+        };
+    }
+
+    it('should run job queries in order (multiple consumers)', function (done) {
+        var jobRequestA1 = createJob([
+            "insert into ordered_inserts values(1)",
+            "select pg_sleep(0.25)",
+            "insert into ordered_inserts values(2)"
+        ]);
+        var jobRequestA2 = createJob([
+            "insert into ordered_inserts values(3)"
+        ]);
+
+        var jobRequestB1 = createJob([
+            "insert into ordered_inserts values(4)"
+        ]);
+
+        var self = this;
+
+        this.batchTestClientA.createJob(jobRequestA1, function(err, jobResultA1) {
+            if (err) {
+                return done(err);
+            }
+
+            // we don't care about the producer
+            self.batchTestClientB.createJob(jobRequestA2, function(err, jobResultA2) {
+                if (err) {
+                    return done(err);
+                }
+
+                var override = { host: 'cartodb250user.cartodb.com' };
+                self.batchTestClientB.createJob(jobRequestB1, override, function(err, jobResultB1) {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    jobResultA1.getStatus(function (err, jobA1) {
+                        if (err) {
+                            return done(err);
+                        }
+                        jobResultA2.getStatus(function(err, jobA2) {
+                            if (err) {
+                                return done(err);
+                            }
+                            jobResultB1.getStatus(function(err, jobB1) {
+                                assert.equal(jobA1.status, JobStatus.DONE);
+                                assert.equal(jobA1.status, JobStatus.DONE);
+                                assert.equal(jobB1.status, JobStatus.DONE);
+
+                                self.testClientA.getResult('select * from ordered_inserts', function(err, rows) {
+                                    assert.ok(!err);
+
+                                    // cartodb250user and vizzuality test users share database
+                                    var expectedRows = [1, 4, 2, 3].map(function(status) { return {status: status}; });
+                                    assert.deepEqual(rows, expectedRows);
+                                    assert.ok(
+                                        new Date(jobA1.updated_at).getTime() < new Date(jobA2.updated_at).getTime(),
+                                        'A1 (' + jobA1.updated_at + ') ' +
+                                            'should finish before A2 (' + jobA2.updated_at + ')'
+                                    );
+                                    assert.ok(
+                                        new Date(jobB1.updated_at).getTime() < new Date(jobA1.updated_at).getTime(),
+                                        'B1 (' + jobA1.updated_at + ') ' +
+                                            'should finish before A1 (' + jobA1.updated_at + ')'
+                                    );
+                                    done();
+                                });
+                            });
+
+                        });
+                    });
+                });
+            });
+        });
+    });
+
+});

--- a/test/acceptance/batch/leader.job.query.order.test.js
+++ b/test/acceptance/batch/leader.job.query.order.test.js
@@ -37,7 +37,7 @@ describe('multiple batch clients job query order', function() {
     it('should run job queries in order (multiple consumers)', function (done) {
         var jobRequest1 = createJob([
             "insert into ordered_inserts values(1)",
-            "select pg_sleep(1)",
+            "select pg_sleep(0.25)",
             "insert into ordered_inserts values(2)"
         ]);
         var jobRequest2 = createJob([

--- a/test/acceptance/batch/queued-jobs-limit.test.js
+++ b/test/acceptance/batch/queued-jobs-limit.test.js
@@ -1,0 +1,67 @@
+require('../../helper');
+
+var assert = require('../../support/assert');
+var redisUtils = require('../../support/redis_utils');
+var batchFactory = require('../../../batch/index');
+var metadataBackend = require('cartodb-redis')(redisUtils.getConfig());
+
+describe('max queued jobs', function() {
+
+    before(function() {
+        this.batch_max_queued_jobs = global.settings.batch_max_queued_jobs;
+        global.settings.batch_max_queued_jobs = 1;
+        this.server = require('../../../app/server')();
+    });
+
+    after(function (done) {
+        global.settings.batch_max_queued_jobs = this.batch_max_queued_jobs;
+        var batch = batchFactory(metadataBackend, redisUtils.getConfig());
+        batch.start();
+        batch.on('ready', function() {
+            batch.stop();
+            redisUtils.clean('batch:*', done);
+        });
+    });
+
+    function createJob(server, status, callback) {
+        assert.response(
+            server,
+            {
+                url: '/api/v2/sql/job?api_key=1234',
+                headers: {
+                    host: 'vizzuality.cartodb.com',
+                    'Content-Type': 'application/json'
+                },
+                method: 'POST',
+                data: JSON.stringify({
+                    query: "SELECT * FROM untitle_table_4"
+                })
+            },
+            {
+                status: status
+            },
+            function(err, res) {
+                if (err) {
+                    return callback(err);
+                }
+
+                return callback(null, JSON.parse(res.body));
+            }
+        );
+    }
+
+    it('POST /api/v2/sql/job should respond with 200 and the created job', function (done) {
+        var self = this;
+        createJob(this.server, 201, function(err) {
+            assert.ok(!err);
+
+            createJob(self.server, 400, function(err, res) {
+                assert.ok(!err);
+                assert.equal(res.error[0], "Failed to create job, max number of jobs queued reached");
+                console.log(res.body);
+                done();
+            });
+        });
+    });
+
+});

--- a/test/integration/batch/job_publisher.test.js
+++ b/test/integration/batch/job_publisher.test.js
@@ -10,29 +10,29 @@ var _ = require('underscore');
 var RedisPool = require('redis-mpool');
 var redisUtils = require('../../support/redis_utils');
 
+
+var Channel = require(BATCH_SOURCE + 'pubsub/channel');
 var JobPublisher = require(BATCH_SOURCE + 'pubsub/job-publisher');
 
 var redisPoolPublisher = new RedisPool(_.extend(redisUtils.getConfig(), { name: 'batch-publisher'}));
 var redisPoolSubscriber = new RedisPool(_.extend(redisUtils.getConfig(), { name: 'batch-subscriber'}));
 
 var HOST = 'wadus';
-var CHANNEL = 'batch:hosts';
-var DB = 0;
 
 describe('job publisher', function() {
     var jobPublisher = new JobPublisher(redisPoolPublisher);
 
     it('.publish() should publish in job channel', function (done) {
-        redisPoolSubscriber.acquire(DB, function (err, client) {
+        redisPoolSubscriber.acquire(Channel.DB, function (err, client) {
             if (err) {
                 return done(err);
             }
 
-            client.subscribe(CHANNEL);
+            client.subscribe(Channel.NAME);
 
             client.on('message', function (channel, host) {
                 assert.equal(host, HOST);
-                assert.equal(channel, CHANNEL) ;
+                assert.equal(channel, Channel.NAME) ;
                 done();
             });
 

--- a/test/integration/batch/queue-seeker.js
+++ b/test/integration/batch/queue-seeker.js
@@ -1,0 +1,68 @@
+'use strict';
+
+require('../../helper');
+var assert = require('../../support/assert');
+var redisUtils = require('../../support/redis_utils');
+
+var metadataBackend = require('cartodb-redis')(redisUtils.getConfig());
+var _ = require('underscore');
+var RedisPool = require('redis-mpool');
+var JobPublisher = require('../../../batch/pubsub/job-publisher');
+var QueueSeeker = require('../../../batch/pubsub/queue-seeker');
+var JobQueue = require('../../../batch/job_queue');
+
+var redisPoolPublisher = new RedisPool(_.extend(redisUtils.getConfig(), { name: 'batch-publisher'}));
+var jobPublisher = new JobPublisher(redisPoolPublisher);
+
+
+describe('queue seeker', function() {
+    var userA = 'userA';
+    var userB = 'userB';
+
+    beforeEach(function () {
+        this.jobQueue = new JobQueue(metadataBackend, jobPublisher);
+    });
+
+    afterEach(function (done) {
+        redisUtils.clean('batch:*', done);
+    });
+
+    it('should find queues for one user', function (done) {
+        var seeker = new QueueSeeker(redisPoolPublisher);
+        this.jobQueue.enqueue(userA, 'wadus-wadus-wadus-wadus', function(err) {
+            if (err) {
+                return done(err);
+            }
+            seeker.seek(function(err, users) {
+                assert.ok(!err);
+                assert.equal(users.length, 1);
+                assert.equal(users[0], userA);
+
+                return done();
+            });
+        });
+    });
+
+    it('should find queues for more than one user', function (done) {
+        var self = this;
+        var seeker = new QueueSeeker(redisPoolPublisher);
+        this.jobQueue.enqueue(userA, 'wadus-wadus-wadus-wadus', function(err) {
+            if (err) {
+                return done(err);
+            }
+            self.jobQueue.enqueue(userB, 'wadus-wadus-wadus-wadus', function(err) {
+                if (err) {
+                    return done(err);
+                }
+                seeker.seek(function(err, users) {
+                    assert.ok(!err);
+                    assert.equal(users.length, 2);
+                    assert.ok(users[0] === userA || users[0] === userB);
+                    assert.ok(users[1] === userA || users[1] === userB);
+
+                    return done();
+                });
+            });
+        });
+    });
+});

--- a/test/support/batch-test-client.js
+++ b/test/support/batch-test-client.js
@@ -45,7 +45,11 @@ BatchTestClient.prototype.isReady = function() {
     return this.ready;
 };
 
-BatchTestClient.prototype.createJob = function(job, callback) {
+BatchTestClient.prototype.createJob = function(job, override, callback) {
+    if (!callback) {
+        callback = override;
+        override = {};
+    }
     if (!this.isReady()) {
         this.pendingJobs.push({
             job: job,
@@ -56,9 +60,9 @@ BatchTestClient.prototype.createJob = function(job, callback) {
     assert.response(
         this.server,
         {
-            url: this.getUrl(),
+            url: this.getUrl(override),
             headers: {
-                host: this.getHost(),
+                host: this.getHost(override),
                 'Content-Type': 'application/json'
             },
             method: 'POST',
@@ -69,18 +73,18 @@ BatchTestClient.prototype.createJob = function(job, callback) {
             if (err) {
                 return callback(err);
             }
-            return callback(null, new JobResult(JSON.parse(res.body), this));
+            return callback(null, new JobResult(JSON.parse(res.body), this, override));
         }.bind(this)
     );
 };
 
-BatchTestClient.prototype.getJobStatus = function(jobId, callback) {
+BatchTestClient.prototype.getJobStatus = function(jobId, override, callback) {
     assert.response(
         this.server,
         {
-            url: this.getUrl(jobId),
+            url: this.getUrl(override, jobId),
             headers: {
-                host: this.getHost()
+                host: this.getHost(override)
             },
             method: 'GET'
         },
@@ -94,13 +98,13 @@ BatchTestClient.prototype.getJobStatus = function(jobId, callback) {
     );
 };
 
-BatchTestClient.prototype.cancelJob = function(jobId, callback) {
+BatchTestClient.prototype.cancelJob = function(jobId, override, callback) {
     assert.response(
         this.server,
         {
             url: this.getUrl(jobId),
             headers: {
-                host: this.getHost()
+                host: this.getHost(override)
             },
             method: 'DELETE'
         },
@@ -120,31 +124,35 @@ BatchTestClient.prototype.drain = function(callback) {
     });
 };
 
-BatchTestClient.prototype.getHost = function() {
-    return this.config.host || 'vizzuality.cartodb.com';
+BatchTestClient.prototype.getHost = function(override) {
+    return override.host || this.config.host || 'vizzuality.cartodb.com';
 };
 
-BatchTestClient.prototype.getUrl = function(jobId) {
+BatchTestClient.prototype.getUrl = function(override, jobId) {
     var urlParts = ['/api/v2/sql/job'];
     if (jobId) {
         urlParts.push(jobId);
     }
-    return urlParts.join('/') + '?api_key=' + (this.config.apiKey || '1234');
+    return urlParts.join('/') + '?api_key=' + this.getApiKey(override);
 };
 
+BatchTestClient.prototype.getApiKey = function(override) {
+    return override.apiKey || this.config.apiKey || '1234';
+};
 
 /****************** JobResult ******************/
 
 
-function JobResult(job, batchTestClient) {
+function JobResult(job, batchTestClient, override) {
     this.job = job;
     this.batchTestClient = batchTestClient;
+    this.override = override;
 }
 
 JobResult.prototype.getStatus = function(callback) {
     var self = this;
     var interval = setInterval(function () {
-        self.batchTestClient.getJobStatus(self.job.job_id, function (err, job) {
+        self.batchTestClient.getJobStatus(self.job.job_id, self.override, function (err, job) {
             if (err) {
                 clearInterval(interval);
                 return callback(err);
@@ -161,5 +169,5 @@ JobResult.prototype.getStatus = function(callback) {
 };
 
 JobResult.prototype.cancel = function(callback) {
-    this.batchTestClient.cancelJob(this.job.job_id, callback);
+    this.batchTestClient.cancelJob(this.job.job_id, this.override, callback);
 };


### PR DESCRIPTION
 - Existing jobs are moved before start processing them.
 - Uses a new queue prefix to avoid collisions.
 - Pub/Sub also changes communication channel.
 - Job subscriber emits user+host on new jobs.
 - Batch processor is faulty. See TODO in batch.js.