### PR TITLE
Accept parameterized queries

### DIFF
--- a/app/controllers/query_controller.js
+++ b/app/controllers/query_controller.js
@@ -37,6 +37,7 @@ QueryController.prototype.handleQuery = function (req, res) {
     var body = (req.body) ? req.body : {};
     var params = _.extend({}, req.query, body); // clone so don't modify req.params or req.body so oauth is not broken
     var sql = params.q;
+    var queryParams = params.params;
     var limit = parseInt(params.rows_per_page);
     var offset = parseInt(params.page);
     var orderBy = params.order_by;
@@ -214,6 +215,7 @@ QueryController.prototype.handleQuery = function (req, res) {
                   dp: dp,
                   skipfields: skipfields,
                   sql: sql,
+                  params: queryParams,
                   filename: filename,
                   bufferedRows: global.settings.bufferedRows,
                   callback: params.callback,

--- a/app/models/formats/pg.js
+++ b/app/models/formats/pg.js
@@ -120,7 +120,7 @@ PostgresFormat.prototype.sendResponse = function(opts, callback) {
   this.start_time = Date.now();
 
   this.client = new PSQL(opts.dbopts, {}, { destroyOnError: true });
-  this.client.eventedQuery(sql, function(err, query, queryCanceller) {
+  this.client.eventedQuery(sql, opts.params, function(err, query, queryCanceller) {
       that.queryCanceller = queryCanceller;
       if (err) {
         callback(err);


### PR DESCRIPTION
Addresses #239 by accepting an array called `params` in the query string, e.g.,

```
{user}.carto.com/api/v2/sql/?api_key=XXXX&sql=SELECT * FROM table WHERE num > $1&params[]=5
// runs SELECT * FROM table WHERE num > 5
```

The important work was already done by @calvinmetcalf in CartoDB/node-cartodb-psql#6, so this is just a 3-line change plus tests.

Currently waiting to hear back about the CLA.