### PR TITLE
Avoid gpkg fid column

### DIFF
--- a/app/models/formats/ogr.js
+++ b/app/models/formats/ogr.js
@@ -60,10 +60,10 @@ OgrFormat.prototype.toOGR = function(options, out_format, out_filename, callback
 
   var ogr2ogr = global.settings.ogr2ogrCommand || 'ogr2ogr';
   var dbhost = dbopts.host;
-  var dbport = dbopts.port; 
-  var dbuser = dbopts.user; 
+  var dbport = dbopts.port;
+  var dbuser = dbopts.user;
   var dbpass = dbopts.pass;
-  var dbname = dbopts.dbname; 
+  var dbname = dbopts.dbname;
 
   var that = this;
 
@@ -72,7 +72,7 @@ OgrFormat.prototype.toOGR = function(options, out_format, out_filename, callback
   var pg;
 
   // Drop ending semicolon (ogr doens't like it)
-  sql = sql.replace(/;\s*$/, ''); 
+  sql = sql.replace(/;\s*$/, '');
 
   step (
 
@@ -162,7 +162,7 @@ OgrFormat.prototype.toOGR = function(options, out_format, out_filename, callback
       }
 
       if (options.cmd_params){
-        ogrargs.concat(options.cmd_params);
+        ogrargs = ogrargs.concat(options.cmd_params);
       }
 
       ogrargs.push('-nln', out_layername);
@@ -318,7 +318,7 @@ ExportRequest.prototype.sendFile = function (err, filename, callback) {
     })
     .on('error', function(e) {
       console.log("Can't send response: " + e);
-      that.ostream.end(); 
+      that.ostream.end();
       callback();
     });
   } else {

--- a/app/models/formats/ogr/geopackage.js
+++ b/app/models/formats/ogr/geopackage.js
@@ -16,6 +16,7 @@ GeoPackageFormat.prototype._fileExtension = "gpkg";
 GeoPackageFormat.prototype._needSRS = true;
 
 GeoPackageFormat.prototype.generate = function(options, callback) {
+    options.cmd_params = ['-lco', 'FID=cartodb_id'];
     this.toOGR_SingleFile(options, 'GPKG', callback);
 };
 

--- a/test/acceptance/export/geopackage.js
+++ b/test/acceptance/export/geopackage.js
@@ -68,6 +68,7 @@ describe('geopackage query', function(){
                   assert.equal(err, null);
                   assert.equal(row.cartodb_id, 1);
                   assert.equal(row.name, 'Hawai');
+                  assert.equal(row.fid, undefined);
                   done();
                 });
                 assert.notEqual(dqr, undefined);


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartodb/issues/9559

This adds `FID = cartodb_id` to the ogr command line for gpkg. The options is documented http://www.gdal.org/drv_geopackage.html. By default, it creates a new column (`fid`) to use as a primary key of the sqlite table. With this option, we tell ogr that it can use `cartodb_id` as a primary key instead (i.e: cartodb_id is numeric and has no duplicates). That avoids creating a new column in the exported file.

CR @rochoa (old-school review assignments). I know this skips all Kanban, but we can consider this an open source contribution. Pretty much I got tired of the fid column and decided to fix it at home.