### PR TITLE
removed incorrect info from versions page of docs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 #Changelog
 
+## 02 August 2017
+Content edits to doc/version.md
+
 ## 1.46.2
 Released 2017-mm-dd
 

--- a/doc/version.md
+++ b/doc/version.md
@@ -1,3 +1,3 @@
 # API Version Number
 
-Ensure that you are using the [latest version](https://github.com/CartoDB/CartoDB-SQL-API) of our SQL API. For example, you can check that you are using **Version 2** by looking at your request URLS. They should all contain **/v2/** in the URLs as follows, `https://{username}.carto.com/api/v2/`
+Ensure that you are using the [latest version](https://github.com/CartoDB/CartoDB-SQL-API) of our SQL API. For example, you can check that you are using **Version 2** by looking at your request URLS. They should all contain **/v2/** in the URLs as follows, `https://{username}.carto.com/api/v2/sql`

--- a/doc/version.md
+++ b/doc/version.md
@@ -1,3 +1,3 @@
 # API Version Number
 
-All CARTO applications use **Version 2** of our APIs. All other APIs are deprecated and will not be maintained or supported. You can check that you are using **Version 2** of our APIs by looking at your request URLS. They should all begin containing **/v2/** in the URLs as follows, `https://{username}.carto.com/api/v2/`
+Ensure that you are using the [latest version](https://github.com/CartoDB/CartoDB-SQL-API) of our SQL API. For example, you can check that you are using **Version 2** by looking at your request URLS. They should all contain **/v2/** in the URLs as follows, `https://{username}.carto.com/api/v2/`


### PR DESCRIPTION
Related to Docs issue: https://github.com/CartoDB/docs/issues/1219

@rochoa , the "Releases" section of this repo does not seem to be related to "version numbers" so I edited the content,  as reported by Support.

Please review and let me know if I can merge until we figure out how/where these "version numbers" are being maintained.