### PR TITLE
Response time limit

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -40,7 +40,7 @@
     "debug"         : false,     // true: Allow debugger statements e.g. browser breakpoints.
 //    "eqnull"        : false,     // true: Tolerate use of `== null`
 //    "es5"           : false,     // true: Allow ES5 syntax (ex: getters and setters)
-//    "esnext"        : false,     // true: Allow ES.next (ES6) syntax (ex: `const`)
+   "esnext"        : true,     // true: Allow ES.next (ES6) syntax (ex: `const`)
 //    "moz"           : false,     // true: Allow Mozilla specific syntax (extends and overrides esnext features)
 //    // (ex: `for each`, multiple try/catch, function expression…)
 //    "evil"          : false,     // true: Tolerate use of `eval` and `new Function()`

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,4 @@ env:
 
 language: node_js
 node_js:
-  - "0.10"
   - "6"

--- a/app/controllers/query_controller.js
+++ b/app/controllers/query_controller.js
@@ -50,6 +50,7 @@ QueryController.prototype.handleQuery = function (req, res) {
     var skipfields;
     var dp = params.dp; // decimal point digits (defaults to 6)
     var gn = "the_geom"; // TODO: read from configuration file
+    var userLimits;
 
     if ( req.profiler ) {
         req.profiler.start('sqlapi.query');
@@ -122,12 +123,13 @@ QueryController.prototype.handleQuery = function (req, res) {
             function getUserDBInfo() {
                 self.userDatabaseService.getConnectionParams(new AuthApi(req, params), cdbUsername, this);
             },
-            function queryExplain(err, dbParams, authDbParams) {
+            function queryExplain(err, dbParams, authDbParams, userTimeoutLimits) {
                 assert.ifError(err);
 
                 var next = this;
 
                 dbopts = dbParams;
+                userLimits = userTimeoutLimits;
 
                 if ( req.profiler ) {
                     req.profiler.done('setDBAuth');
@@ -217,7 +219,8 @@ QueryController.prototype.handleQuery = function (req, res) {
                   filename: filename,
                   bufferedRows: global.settings.bufferedRows,
                   callback: params.callback,
-                  abortChecker: checkAborted
+                  abortChecker: checkAborted,
+                  timeout: userLimits.timeout
                 };
 
                 if ( req.profiler ) {

--- a/app/models/formats/ogr.js
+++ b/app/models/formats/ogr.js
@@ -169,14 +169,14 @@ OgrFormat.prototype.toOGR = function(options, out_format, out_filename, callback
 
       ogrargs.push('-nln', out_layername);
 
-      // TODO: research if exec
+      // TODO: research if `exec` could fit better than `spawn`
       var child = spawn(ogr2ogr, ogrargs);
 
-      var timeouted = false;
+      var timedOut = false;
       var ogrTimeout;
       if (timeout > 0) {
         ogrTimeout = setTimeout(function () {
-          timeouted = true;
+          timedOut = true;
           child.kill();
         }, timeout);
       }
@@ -195,7 +195,7 @@ OgrFormat.prototype.toOGR = function(options, out_format, out_filename, callback
       child.on('exit', function(code) {
         clearTimeout(ogrTimeout);
 
-        if (timeouted) {
+        if (timedOut) {
           return next(new Error('You are over platform\'s limits. Please contact us to know more details'));
         }
 

--- a/app/models/formats/ogr.js
+++ b/app/models/formats/ogr.js
@@ -65,6 +65,8 @@ OgrFormat.prototype.toOGR = function(options, out_format, out_filename, callback
   var dbpass = dbopts.pass;
   var dbname = dbopts.dbname;
 
+  var timeout = options.timeout;
+
   var that = this;
 
   var columns = [];
@@ -167,9 +169,20 @@ OgrFormat.prototype.toOGR = function(options, out_format, out_filename, callback
 
       ogrargs.push('-nln', out_layername);
 
+      // TODO: research if exec
       var child = spawn(ogr2ogr, ogrargs);
 
+      var timeouted = false;
+      var ogrTimeout;
+      if (timeout > 0) {
+        ogrTimeout = setTimeout(function () {
+          timeouted = true;
+          child.kill();
+        }, timeout);
+      }
+
       child.on('error', function (err) {
+        clearTimeout(ogrTimeout);
         next(err);
       });
 
@@ -180,6 +193,12 @@ OgrFormat.prototype.toOGR = function(options, out_format, out_filename, callback
       });
 
       child.on('exit', function(code) {
+        clearTimeout(ogrTimeout);
+
+        if (timeouted) {
+          return next(new Error('You are over platform\'s limits. Please contact us to know more details'));
+        }
+
         if (code !== 0) {
           var errMessage = 'ogr2ogr command return code ' + code;
           if (stderrData.length > 0) {

--- a/app/postgresql/error_handler.js
+++ b/app/postgresql/error_handler.js
@@ -40,12 +40,14 @@ ErrorHandler.prototype.getStatus = function() {
         statusError = 401;
     }
 
+    if (message === conditionToMessage[pgErrorCodes.conditionToCode.query_canceled]) {
+        statusError = 429;
+    }
+
     return statusError;
 };
 
 var conditionToMessage = {};
 conditionToMessage[pgErrorCodes.conditionToCode.query_canceled] = [
-    "Your query was not able to finish.",
-    "Either you have too many queries running or the one you are trying to run is too expensive.",
-    "Try again."
+    'You are over platform\'s limits. Please contact us to know more details'
 ].join(' ');

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -171,9 +171,9 @@
       "resolved": "https://registry.npmjs.org/cartodb-query-tables/-/cartodb-query-tables-0.2.0.tgz"
     },
     "cartodb-redis": {
-      "version": "0.13.3",
-      "from": "cartodb/node-cartodb-redis#timeout-limits",
-      "resolved": "git://github.com/cartodb/node-cartodb-redis.git#3e02e9fa38e2b98423f811705c1f7fb8c4f70c95"
+      "version": "0.14.0",
+      "from": "cartodb-redis@0.14.0",
+      "resolved": "https://registry.npmjs.org/cartodb-redis/-/cartodb-redis-0.14.0.tgz"
     },
     "debug": {
       "version": "2.2.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,11 +1,21 @@
 {
   "name": "cartodb_sql_api",
-  "version": "1.46.0",
+  "version": "1.46.2",
   "dependencies": {
+    "ap": {
+      "version": "0.2.0",
+      "from": "ap@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/ap/-/ap-0.2.0.tgz"
+    },
     "bintrees": {
       "version": "1.0.1",
       "from": "bintrees@1.0.1",
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz"
+    },
+    "buffer-writer": {
+      "version": "1.0.1",
+      "from": "buffer-writer@1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz"
     },
     "bunyan": {
       "version": "1.8.1",
@@ -153,111 +163,7 @@
     "cartodb-psql": {
       "version": "0.7.1",
       "from": "cartodb-psql@0.7.1",
-      "resolved": "https://registry.npmjs.org/cartodb-psql/-/cartodb-psql-0.7.1.tgz",
-      "dependencies": {
-        "pg": {
-          "version": "6.1.2",
-          "from": "cartodb/node-postgres#6.1.2-cdb1",
-          "resolved": "git://github.com/cartodb/node-postgres.git#3c81aea432ce58d20a795786c58bbb14f68f9689",
-          "dependencies": {
-            "buffer-writer": {
-              "version": "1.0.1",
-              "from": "buffer-writer@1.0.1",
-              "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz"
-            },
-            "packet-reader": {
-              "version": "0.2.0",
-              "from": "packet-reader@0.2.0",
-              "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.2.0.tgz"
-            },
-            "pg-connection-string": {
-              "version": "0.1.3",
-              "from": "pg-connection-string@0.1.3",
-              "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz"
-            },
-            "pg-pool": {
-              "version": "1.7.1",
-              "from": "pg-pool@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-1.7.1.tgz",
-              "dependencies": {
-                "generic-pool": {
-                  "version": "2.4.3",
-                  "from": "generic-pool@2.4.3",
-                  "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.4.3.tgz"
-                },
-                "object-assign": {
-                  "version": "4.1.0",
-                  "from": "object-assign@4.1.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
-                }
-              }
-            },
-            "pg-types": {
-              "version": "1.11.0",
-              "from": "pg-types@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.11.0.tgz",
-              "dependencies": {
-                "ap": {
-                  "version": "0.2.0",
-                  "from": "ap@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/ap/-/ap-0.2.0.tgz"
-                },
-                "postgres-array": {
-                  "version": "1.0.2",
-                  "from": "postgres-array@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.2.tgz"
-                },
-                "postgres-bytea": {
-                  "version": "1.0.0",
-                  "from": "postgres-bytea@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz"
-                },
-                "postgres-date": {
-                  "version": "1.0.3",
-                  "from": "postgres-date@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.3.tgz"
-                },
-                "postgres-interval": {
-                  "version": "1.0.2",
-                  "from": "postgres-interval@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.0.2.tgz",
-                  "dependencies": {
-                    "xtend": {
-                      "version": "4.0.1",
-                      "from": "xtend@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "pgpass": {
-              "version": "1.0.1",
-              "from": "pgpass@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.1.tgz",
-              "dependencies": {
-                "split": {
-                  "version": "1.0.0",
-                  "from": "split@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/split/-/split-1.0.0.tgz",
-                  "dependencies": {
-                    "through": {
-                      "version": "2.3.8",
-                      "from": "through@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "semver": {
-              "version": "4.3.2",
-              "from": "semver@4.3.2",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz"
-            }
-          }
-        }
-      }
+      "resolved": "https://registry.npmjs.org/cartodb-psql/-/cartodb-psql-0.7.1.tgz"
     },
     "cartodb-query-tables": {
       "version": "0.2.0",
@@ -265,16 +171,9 @@
       "resolved": "https://registry.npmjs.org/cartodb-query-tables/-/cartodb-query-tables-0.2.0.tgz"
     },
     "cartodb-redis": {
-      "version": "0.13.2",
-      "from": "cartodb-redis@0.13.2",
-      "resolved": "https://registry.npmjs.org/cartodb-redis/-/cartodb-redis-0.13.2.tgz",
-      "dependencies": {
-        "dot": {
-          "version": "1.0.3",
-          "from": "dot@>=1.0.2 <1.1.0",
-          "resolved": "https://registry.npmjs.org/dot/-/dot-1.0.3.tgz"
-        }
-      }
+      "version": "0.13.3",
+      "from": "cartodb/node-cartodb-redis#timeout-limits",
+      "resolved": "git://github.com/cartodb/node-cartodb-redis.git#3e02e9fa38e2b98423f811705c1f7fb8c4f70c95"
     },
     "debug": {
       "version": "2.2.0",
@@ -287,6 +186,11 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         }
       }
+    },
+    "dot": {
+      "version": "1.0.3",
+      "from": "dot@>=1.0.2 <1.1.0",
+      "resolved": "https://registry.npmjs.org/dot/-/dot-1.0.3.tgz"
     },
     "express": {
       "version": "4.13.4",
@@ -554,6 +458,11 @@
         }
       }
     },
+    "generic-pool": {
+      "version": "2.4.3",
+      "from": "generic-pool@2.4.3",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.4.3.tgz"
+    },
     "log4js": {
       "version": "0.6.25",
       "from": "cartodb/log4js-node#cdb",
@@ -799,6 +708,61 @@
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.1.0.tgz"
         }
       }
+    },
+    "object-assign": {
+      "version": "4.1.0",
+      "from": "object-assign@4.1.0",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+    },
+    "packet-reader": {
+      "version": "0.2.0",
+      "from": "packet-reader@0.2.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.2.0.tgz"
+    },
+    "pg": {
+      "version": "6.1.2",
+      "from": "cartodb/node-postgres#6.1.2-cdb1",
+      "resolved": "git://github.com/cartodb/node-postgres.git#3c81aea432ce58d20a795786c58bbb14f68f9689"
+    },
+    "pg-connection-string": {
+      "version": "0.1.3",
+      "from": "pg-connection-string@0.1.3",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz"
+    },
+    "pg-pool": {
+      "version": "1.8.0",
+      "from": "pg-pool@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-1.8.0.tgz"
+    },
+    "pg-types": {
+      "version": "1.12.0",
+      "from": "pg-types@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.12.0.tgz"
+    },
+    "pgpass": {
+      "version": "1.0.2",
+      "from": "pgpass@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz"
+    },
+    "postgres-array": {
+      "version": "1.0.2",
+      "from": "postgres-array@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.2.tgz"
+    },
+    "postgres-bytea": {
+      "version": "1.0.0",
+      "from": "postgres-bytea@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz"
+    },
+    "postgres-date": {
+      "version": "1.0.3",
+      "from": "postgres-date@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.3.tgz"
+    },
+    "postgres-interval": {
+      "version": "1.1.1",
+      "from": "postgres-interval@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.1.1.tgz"
     },
     "qs": {
       "version": "6.2.3",
@@ -1244,6 +1208,16 @@
         }
       }
     },
+    "semver": {
+      "version": "4.3.2",
+      "from": "semver@4.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz"
+    },
+    "split": {
+      "version": "1.0.1",
+      "from": "split@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz"
+    },
     "step": {
       "version": "0.0.6",
       "from": "step@>=0.0.5 <0.1.0",
@@ -1253,6 +1227,11 @@
       "version": "0.3.0",
       "from": "step-profiler@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/step-profiler/-/step-profiler-0.3.0.tgz"
+    },
+    "through": {
+      "version": "2.3.8",
+      "from": "through@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
     },
     "topojson": {
       "version": "0.0.8",
@@ -1277,6 +1256,11 @@
       "version": "1.6.0",
       "from": "underscore@>=1.6.0 <1.7.0",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "from": "xtend@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     },
     "yargs": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bunyan": "1.8.1",
     "cartodb-psql": "0.7.1",
     "cartodb-query-tables": "0.2.0",
-    "cartodb-redis": "0.13.2",
+    "cartodb-redis": "github:cartodb/node-cartodb-redis#timeout-limits",
     "debug": "2.2.0",
     "express": "~4.13.3",
     "log4js": "cartodb/log4js-node#cdb",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bunyan": "1.8.1",
     "cartodb-psql": "0.7.1",
     "cartodb-query-tables": "0.2.0",
-    "cartodb-redis": "github:cartodb/node-cartodb-redis#timeout-limits",
+    "cartodb-redis": "0.14.0",
     "debug": "2.2.0",
     "express": "~4.13.3",
     "log4js": "cartodb/log4js-node#cdb",

--- a/test/acceptance/app.test.js
+++ b/test/acceptance/app.test.js
@@ -782,10 +782,19 @@ it('GET with callback must return 200 status error even if it is an error', func
                 method: 'GET'
             },
             {
-                status: 400
+                status: 429,
+                headers: {
+                    'Content-Type': 'application/json; charset=utf-8'
+                }
             },
             function(err, res) {
-                assert.ok(res.body.match(/was not able to finish.*try again/i));
+                var error = JSON.parse(res.body);
+                assert.deepEqual(error, {
+                    error: [
+                        'You are over platform\'s limits. Please contact us to know more details'
+                    ]
+                });
+
                 done();
             });
     });

--- a/test/acceptance/export/timeout.js
+++ b/test/acceptance/export/timeout.js
@@ -1,0 +1,34 @@
+const TestClient = require('../../support/test-client');
+
+require('../../support/assert');
+
+var assert = require('assert');
+var server = require('../../../app/server')();
+var querystring = require('querystring');
+
+describe('export timeout', function () {
+    beforeEach(function () {
+        this.testClient = new TestClient();
+    });
+
+    it('CSV export with slow query exceeding statement timeout returns proper error message', function (done) {
+        const override = {
+            format: 'csv',
+            response: {
+                status: 429
+            }
+        };
+
+        this.testClient.getResult('select pg_sleep(2.1) as sleep, 1 as value', override, function (err, res) {
+            assert.ifError(err);
+
+            assert.deepEqual(res, {
+                error: [
+                    'You are over platform\'s limits. Please contact us to know more details'
+                ]
+            });
+
+            done();
+        });
+    });
+});

--- a/test/acceptance/export/timeout.js
+++ b/test/acceptance/export/timeout.js
@@ -3,7 +3,6 @@ const TestClient = require('../../support/test-client');
 require('../../support/assert');
 
 var assert = require('assert');
-var server = require('../../../app/server')();
 var querystring = require('querystring');
 
 describe('export timeout', function () {
@@ -11,24 +10,79 @@ describe('export timeout', function () {
         this.testClient = new TestClient();
     });
 
-    it('CSV export with slow query exceeding statement timeout returns proper error message', function (done) {
-        const override = {
+    const scenarios = [
+        {
+            desc: 'CSV',
             format: 'csv',
-            response: {
-                status: 429
-            }
-        };
+            contentType: 'application/x-www-form-urlencoded',
+            parser: querystring.stringify,
+            // only: true,
+            skip: true
+        },
+        {
+            desc: 'Geopackage',
+            format: 'gpkg'
+        },
+        {
+            desc: 'KML',
+            format: 'kml'
+        },
+        {
+            desc: 'Shapefile',
+            format: 'shp'
+        },
+        {
+            desc: 'Spatialite',
+            format: 'spatialite'
+        },
+        {
+            desc: 'Array Buffer',
+            format: 'arraybuffer'
+        },
+        {
+            desc: 'GeoJSON',
+            format: 'geojson'
+        },
+        {
+            desc: 'JSON',
+            format: 'json'
+        },
+        {
+            desc: 'SVG',
+            format: 'svg'
+        },
+        {
+            desc: 'TopoJSON',
+            format: 'topojson'
+        }
+    ];
 
-        this.testClient.getResult('select pg_sleep(2.1) as sleep, 1 as value', override, function (err, res) {
-            assert.ifError(err);
+    scenarios.forEach((scenario) => {
+        const test = scenario.only ? it.only : scenario.skip ? it.skip : it;
 
-            assert.deepEqual(res, {
-                error: [
-                    'You are over platform\'s limits. Please contact us to know more details'
-                ]
+        test(`${scenario.desc} export exceeding statement timeout responds 429 Over Limits`, function (done) {
+            const override = {
+                'Content-Type': scenario.contentType,
+                parser: scenario.parser,
+                anonymous: true,
+                format: scenario.format,
+                response: {
+                    status: 429
+                }
+            };
+
+            const query = 'select ST_SetSRID(ST_Point(0, 0), 4326) as the_geom, pg_sleep(2.1) as sleep, 1 as value';
+            this.testClient.getResult(query, override, function (err, res) {
+                assert.ifError(err);
+
+                assert.deepEqual(res, {
+                    error: [
+                        'You are over platform\'s limits. Please contact us to know more details'
+                    ]
+                });
+
+                done();
             });
-
-            done();
         });
     });
 });

--- a/test/support/redis_utils.js
+++ b/test/support/redis_utils.js
@@ -33,3 +33,7 @@ var pool = new RedisPool(redisConfig);
 module.exports.getPool = function getPool() {
     return pool;
 };
+
+module.exports.configureUserMetadata = function configureUserMetadata(action, params, callback) {
+    metadataBackend.redisCmd(5, action, params, callback);
+}

--- a/test/support/test-client.js
+++ b/test/support/test-client.js
@@ -35,10 +35,10 @@ TestClient.prototype.getResult = function(query, override, callback) {
             url: this.getUrl(override),
             headers: {
                 host: this.getHost(override),
-                'Content-Type': 'application/json'
+                'Content-Type': this.getContentType(override)
             },
             method: 'POST',
-            data: JSON.stringify({
+            data: this.getParser(override)({
                 q: query,
                 format: this.getFormat(override)
             })
@@ -50,7 +50,7 @@ TestClient.prototype.getResult = function(query, override, callback) {
             }
             var result = JSON.parse(res.body);
 
-            if (res.status > 299) {
+            if (res.statusCode > 299) {
                 return callback(null, result);
             }
 
@@ -63,7 +63,19 @@ TestClient.prototype.getHost = function(override) {
     return override.host || this.config.host || 'vizzuality.cartodb.com';
 };
 
+TestClient.prototype.getContentType = function(override) {
+    return override['Content-Type'] || this.config['Content-Type'] || 'application/json';
+};
+
+TestClient.prototype.getParser = function (override) {
+    return override.parser || this.config.parser || JSON.stringify
+}
+
 TestClient.prototype.getUrl = function(override) {
+    if (override.anonymous) {
+        return '/api/v1/sql?';
+    }
+
     return '/api/v2/sql?api_key=' + (override.apiKey || this.config.apiKey || '1234');
 };
 
@@ -74,3 +86,5 @@ TestClient.prototype.getExpectedResponse = function (override) {
 TestClient.prototype.getFormat = function (override) {
     return override.format || this.config.format || undefined;
 };
+
+

--- a/test/support/test-client.js
+++ b/test/support/test-client.js
@@ -39,15 +39,20 @@ TestClient.prototype.getResult = function(query, override, callback) {
             },
             method: 'POST',
             data: JSON.stringify({
-                q: query
+                q: query,
+                format: this.getFormat(override)
             })
         },
-        RESPONSE.OK,
+        this.getExpectedResponse(override),
         function (err, res) {
             if (err) {
                 return callback(err);
             }
             var result = JSON.parse(res.body);
+
+            if (res.status > 299) {
+                return callback(null, result);
+            }
 
             return callback(null, result.rows || []);
         }
@@ -60,4 +65,12 @@ TestClient.prototype.getHost = function(override) {
 
 TestClient.prototype.getUrl = function(override) {
     return '/api/v2/sql?api_key=' + (override.apiKey || this.config.apiKey || '1234');
+};
+
+TestClient.prototype.getExpectedResponse = function (override) {
+    return override.response || this.config.response || RESPONSE.OK;
+};
+
+TestClient.prototype.getFormat = function (override) {
+    return override.format || this.config.format || undefined;
 };

--- a/test/support/test-client.js
+++ b/test/support/test-client.js
@@ -7,6 +7,7 @@ var redisUtils = require('./redis_utils');
 const step = require('step');
 const PSQL = require('cartodb-psql');
 const _ = require('underscore');
+// TODO: remove after upgrading cartodb-psql to 0.9.0
 const pg = require('pg');
 
 function response(code) {
@@ -114,6 +115,7 @@ TestClient.prototype.setUserDatabaseTimeoutLimit = function (user, timeoutLimit,
     const pass = _.template(global.settings.db_user_pass, { user_id: 1 })
     const publicuser = global.settings.db_pubuser;
 
+    // TODO: We do need to upgrade cartodb-psql to 0.9.0 to use psql.end() instead.
     // we need to guarantee all new connections have the new settings
     pg.end();
 


### PR DESCRIPTION
Implements #421.

This PR aims to ensure that Export API and Query API responds with `429 You are over the limits` when a `query` or `ogr command` overcome the pre-configured timeout for any user.