### PR TITLE
1.29.2 fix pg vulnerability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 before_script:
   - lsb_release -a
-  - sudo mv /etc/apt/sources.list.d/pgdg-source.list* /tmp
+  - sudo mv /etc/apt/sources.list.d/pgdg.list* /tmp
   - sudo apt-get -qq purge postgis* postgresql*
   - sudo rm -Rf /var/lib/postgresql /etc/postgresql
   - sudo apt-add-repository --yes ppa:cartodb/postgresql-9.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,16 @@ before_script:
   - sudo mv /etc/apt/sources.list.d/pgdg-source.list* /tmp
   - sudo apt-get -qq purge postgis* postgresql*
   - sudo rm -Rf /var/lib/postgresql /etc/postgresql
-  - sudo apt-add-repository --yes ppa:cartodb/postgresql-9.3
+  - sudo apt-add-repository --yes ppa:cartodb/postgresql-9.5
   - sudo apt-add-repository --yes ppa:cartodb/gis
   - sudo apt-get update
-  - sudo apt-get install -q postgresql-9.3-postgis-2.1
-  - sudo apt-get install -q postgresql-contrib-9.3
-  - sudo apt-get install -q postgresql-plpython-9.3
+  - sudo apt-get install -q postgresql-9.5-postgis-2.2
+  - sudo apt-get install -q postgresql-contrib-9.5
+  - sudo apt-get install -q postgresql-plpython-9.5
   - sudo apt-get install -q postgis
   - sudo apt-get install -q gdal-bin
   - sudo apt-get install -q ogr2ogr2-static-bin
-  - echo -e "local\tall\tall\ttrust\nhost\tall\tall\t127.0.0.1/32\ttrust\nhost\tall\tall\t::1/128\ttrust" |sudo tee /etc/postgresql/9.3/main/pg_hba.conf
+  - echo -e "local\tall\tall\ttrust\nhost\tall\tall\t127.0.0.1/32\ttrust\nhost\tall\tall\t::1/128\ttrust" |sudo tee /etc/postgresql/9.5/main/pg_hba.conf
   - sudo service postgresql restart
   - psql -c 'create database template_postgis;' -U postgres
   - psql -c 'CREATE EXTENSION postgis;' -U postgres -d template_postgis

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+1.29.3 - 2017-08-31
+-------------------
+
+Bug fixes:
+ *  Adding a new cartodb-psql fixing a pg vulnerability
+
+
 1.29.2 - 2016-05-25
 -------------------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
-1.29.2 - 2016-mm-dd
+1.29.2 - 2016-05-25
 -------------------
+
+Bug fixes:
+ * Fixed issue with status transition in fallback jobs #308
 
 
 1.29.1 - 2016-05-24

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "cartodb-psql": {
       "version": "0.6.2",
-      "from": "cartodb-psql@0.6.2",
+      "from": "cartodb-psql@>=0.6.0 <0.7.0",
       "dependencies": {
         "pg": {
           "version": "2.6.2-cdb4",
@@ -164,7 +164,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "inherits@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             }
           }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,16 +1,15 @@
 {
   "name": "cartodb_sql_api",
-  "version": "1.29.2",
+  "version": "1.29.3",
   "dependencies": {
     "cartodb-psql": {
-      "version": "0.6.1",
-      "from": "cartodb-psql@>=0.6.0 <0.7.0",
-      "resolved": "https://registry.npmjs.org/cartodb-psql/-/cartodb-psql-0.6.1.tgz",
+      "version": "0.6.2",
+      "from": "cartodb-psql@0.6.2",
       "dependencies": {
         "pg": {
-          "version": "2.6.2-cdb3",
-          "from": "git://github.com/CartoDB/node-postgres.git#2.6.2-cdb3",
-          "resolved": "git://github.com/CartoDB/node-postgres.git#069c5296d1a093077feff21719641bb9e71fc50e",
+          "version": "2.6.2-cdb4",
+          "from": "git://github.com/CartoDB/node-postgres.git#2.6.2-cdb4",
+          "resolved": "git://github.com/CartoDB/node-postgres.git#9fad6b99e5355285343f7b0ea1eb5e6d3f888edf",
           "dependencies": {
             "generic-pool": {
               "version": "2.0.3",
@@ -21,6 +20,11 @@
               "version": "1.0.0",
               "from": "buffer-writer@1.0.0",
               "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.0.tgz"
+            },
+            "js-string-escape": {
+              "version": "1.0.1",
+              "from": "js-string-escape@1.0.1",
+              "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz"
             }
           }
         }
@@ -67,9 +71,9 @@
               "resolved": "https://registry.npmjs.org/hiredis/-/hiredis-0.1.17.tgz",
               "dependencies": {
                 "bindings": {
-                  "version": "1.2.1",
+                  "version": "1.3.0",
                   "from": "bindings@*",
-                  "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
+                  "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz"
                 },
                 "nan": {
                   "version": "1.1.2",
@@ -159,9 +163,9 @@
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "inherits": {
-              "version": "2.0.1",
+              "version": "2.0.3",
               "from": "inherits@>=2.0.1 <2.1.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             }
           }
         },
@@ -188,9 +192,9 @@
       "resolved": "https://registry.npmjs.org/node-statsd/-/node-statsd-0.0.7.tgz"
     },
     "node-uuid": {
-      "version": "1.4.7",
+      "version": "1.4.8",
       "from": "node-uuid@>=1.4.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz"
     },
     "oauth-client": {
       "version": "0.3.0",
@@ -210,9 +214,9 @@
       "resolved": "https://registry.npmjs.org/queue-async/-/queue-async-1.0.7.tgz"
     },
     "redis": {
-      "version": "2.5.3",
+      "version": "2.8.0",
       "from": "redis@>=2.4.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-2.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
       "dependencies": {
         "double-ended-queue": {
           "version": "2.1.0-0",
@@ -220,14 +224,14 @@
           "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz"
         },
         "redis-commands": {
-          "version": "1.2.0",
-          "from": "redis-commands@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.2.0.tgz"
+          "version": "1.3.1",
+          "from": "redis-commands@>=1.2.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz"
         },
         "redis-parser": {
-          "version": "1.3.0",
-          "from": "redis-parser@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-1.3.0.tgz"
+          "version": "2.6.0",
+          "from": "redis-parser@>=2.6.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "Sandro Santilli <strk@vizzuality.com>"
     ],
     "dependencies": {
-        "cartodb-psql": "~0.6.0",
+        "cartodb-psql": "0.6.2",
         "cartodb-redis": "~0.11.0",
         "debug": "2.2.0",
         "express": "~2.5.11",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "Sandro Santilli <strk@vizzuality.com>"
     ],
     "dependencies": {
-        "cartodb-psql": "0.6.2",
+        "cartodb-psql": "~0.6.0",
         "cartodb-redis": "~0.11.0",
         "debug": "2.2.0",
         "express": "~2.5.11",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "keywords": [
         "cartodb"
     ],
-    "version": "1.29.2",
+    "version": "1.29.3",
     "repository": {
         "type": "git",
         "url": "git://github.com/CartoDB/CartoDB-SQL-API.git"

--- a/test/prepare_db.sh
+++ b/test/prepare_db.sh
@@ -85,7 +85,7 @@ if test x"$PREPARE_PGSQL" = xyes; then
 
   # TODO: send in a single run, togheter with test.sql
   psql -c "CREATE EXTENSION plpythonu;" ${TEST_DB}
-  for i in CDB_QueryStatements CDB_QueryTables CDB_CartodbfyTable CDB_TableMetadata CDB_ForeignTable CDB_UserTables CDB_ColumnNames CDB_ZoomFromScale CDB_Overviews
+  for i in CDB_QueryStatements CDB_QueryTables CDB_CartodbfyTable CDB_TableMetadata CDB_ForeignTable CDB_UserTables CDB_ColumnNames CDB_ZoomFromScale CDB_OverviewsSupport CDB_Overviews
   do
     curl -L -s https://github.com/CartoDB/cartodb-postgresql/raw/master/scripts-available/$i.sql -o support/$i.sql
     cat support/$i.sql | sed -e 's/cartodb\./public./g' -e "s/''cartodb''/''public''/g" \


### PR DESCRIPTION
This PR updated the old 1.29.2 version with:
- Adding a new cartodb-psql fixing the pg vulnerability
- Added some changes to pass test (upgrading old versions or old assets difficult to find today)

This will be the tag 1.29.3

-----------------

More info about pg vulnerability 
https://node-postgres.com/announcements#2017-08-12-code-execution-vulnerability