### PR TITLE
Test: Strip PARALLEL labels for PostgreSQL releases before 9.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,23 +5,45 @@ addons:
     - ubuntu-toolchain-r-test
     packages:
     - g++-4.8
+  postgresql: 9.5
 
 before_install:
-  - lsb_release -a
-  - sudo mv /etc/apt/sources.list.d/pgdg.list* /tmp
-  - sudo apt-get -qq purge postgis* postgresql*
-  - sudo rm -Rf /var/lib/postgresql /etc/postgresql
-  - sudo apt-add-repository --yes ppa:cartodb/postgresql-9.5
-  - sudo apt-add-repository --yes ppa:cartodb/gis
+  # Add custom PPAs from cartodb
+  - sudo add-apt-repository -y ppa:cartodb/postgresql-9.5
+  - sudo add-apt-repository -y ppa:cartodb/gis
+  - sudo add-apt-repository -y ppa:cartodb/gis-testing
   - sudo apt-get update
-  - sudo apt-get install -q postgresql-9.5-postgis-2.2
-  - sudo apt-get install -q postgresql-contrib-9.5
-  - sudo apt-get install -q postgresql-plpython-9.5
-  - sudo apt-get install -q postgis
+
+  # Force instalation of libgeos-3.5.0 (presumably needed because of existing version of postgis)
+  - sudo apt-get -y install libgeos-3.5.0=3.5.0-1cdb2
+
+  # Install postgres db and build deps
+  - sudo /etc/init.d/postgresql stop # stop travis default instance
+  - sudo apt-get -y remove --purge postgresql-9.1
+  - sudo apt-get -y remove --purge postgresql-9.2
+  - sudo apt-get -y remove --purge postgresql-9.3
+  - sudo apt-get -y remove --purge postgresql-9.4
+  - sudo apt-get -y remove --purge postgresql-9.5
+  - sudo apt-get -y remove --purge postgresql-9.6
+  - sudo rm -rf /var/lib/postgresql/
+  - sudo rm -rf /var/log/postgresql/
+  - sudo rm -rf /etc/postgresql/
+  - sudo apt-get -y remove --purge postgis-2.2
+  - sudo apt-get -y autoremove
+
+  - sudo apt-get -y install postgresql-9.5=9.5.2-3cdb3
+  - sudo apt-get -y install postgresql-server-dev-9.5=9.5.2-3cdb3
+  - sudo apt-get -y install postgresql-plpython-9.5=9.5.2-3cdb3
+  - sudo apt-get -y install postgresql-9.5-postgis-scripts=2.2.2.0-cdb2
+  - sudo apt-get -y install postgresql-9.5-postgis-2.2=2.2.2.0-cdb2
   - sudo apt-get install -q gdal-bin
   - sudo apt-get install -q ogr2ogr2-static-bin
-  - echo -e "local\tall\tall\ttrust\nhost\tall\tall\t127.0.0.1/32\ttrust\nhost\tall\tall\t::1/128\ttrust" |sudo tee /etc/postgresql/9.5/main/pg_hba.conf
-  - sudo service postgresql restart
+
+  # configure it to accept local connections from postgres
+  - echo -e "# TYPE  DATABASE        USER            ADDRESS                 METHOD \nlocal   all             postgres                                trust\nlocal   all             all                                     trust\nhost    all             all             127.0.0.1/32            trust" \
+    | sudo tee /etc/postgresql/9.5/main/pg_hba.conf
+  - sudo /etc/init.d/postgresql restart 9.5
+
   - psql -c 'create database template_postgis;' -U postgres
   - psql -c 'CREATE EXTENSION postgis;' -U postgres -d template_postgis
   - ./configure

--- a/test/prepare_db.sh
+++ b/test/prepare_db.sh
@@ -88,10 +88,19 @@ if test x"$PREPARE_PGSQL" = xyes; then
       echo ${CURL_ARGS} | xargs curl -L -s
   fi
 
+  PG_PARALLEL=$(pg_config --version | (awk '{$2*=1000; if ($2 >= 9600) print 1; else print 0;}' 2> /dev/null || echo 0))
+
   psql -c "CREATE EXTENSION IF NOT EXISTS plpythonu;" ${TEST_DB}
   ALL_SQL_SCRIPTS="${REMOTE_SQL_SCRIPTS} ${LOCAL_SQL_SCRIPTS}"
   for i in ${ALL_SQL_SCRIPTS}
   do
+    # Strip PARALLEL labels for PostgreSQL releases before 9.6
+    if [ $PG_PARALLEL -eq 0 ]; then
+      TMPFILE=$(mktemp /tmp/$(basename $0).XXXXXXXX)
+      sed -e 's/PARALLEL \= [A-Z]*,/''/g' \
+          -e 's/PARALLEL [A-Z]*/''/g' support/sql/${i}.sql > $TMPFILE
+      mv $TMPFILE support/sql/${i}.sql
+    fi
     cat support/sql/${i}.sql |
       sed -e 's/cartodb\./public./g' -e "s/''cartodb''/''public''/g" |
       sed "s/:PUBLICUSER/${PUBLICUSER}/" |


### PR DESCRIPTION
Same patch as done for https://github.com/CartoDB/Windshaft-cartodb/pull/791. Since it's downloading individual files instead of the extension itself it needs to remove PARALLEL labels.