### PR TITLE
fix postgres version on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,10 @@ before_install:
   - sudo apt-get -y remove --purge postgis-2.2
   - sudo apt-get -y autoremove
 
-  - sudo apt-get -y install postgresql-9.5=9.5.2-3cdb3
-  - sudo apt-get -y install postgresql-server-dev-9.5=9.5.2-3cdb3
-  - sudo apt-get -y install postgresql-plpython-9.5=9.5.2-3cdb3
   - sudo apt-get -y install postgresql-9.5-postgis-scripts=2.2.2.0-cdb2
+  - sudo apt-get -y install postgresql-9.5=9.5.2-3cdb3 --allow-downgrades
+  - sudo apt-get -y install postgresql-server-dev-9.5=9.5.2-3cdb3
+  - sudo apt-get -y install postgresql-plpython-9.5=9.5.2-3cdb3 --allow-downgrades
   - sudo apt-get -y install postgresql-9.5-postgis-2.2=2.2.2.0-cdb2
   - sudo apt-get install -q gdal-bin
   - sudo apt-get install -q ogr2ogr2-static-bin

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ Announcements:
  * Documentation updates for Docs repo issue #840, GPKG Export.
  * Fix SHP exports, now it uses "the_geom" column by default when a dataset has more than one geometry column.
  * Logging all errors
+ * Fix postgres version in travis
 
 
 ## 1.47.1


### PR DESCRIPTION
Working on https://github.com/CartoDB/CartoDB-SQL-API/pull/448#issuecomment-349339179 I have shown the `postgresql-9.5=9.5.2-3cdb3` and `postgresql-plpython-9.5=9.5.2-3cdb3` are overwritten by `postgresql-9.5-postgis-scripts` installing the default version (currently 9.5.7).
  
As a result, when we run the command `psql -A -t -c 'select version()` before running the tests, we have `PostgreSQL 9.5.7 on ...` instead of the expected `PostgreSQL 9.5.2 on ...`, so we are not working with our custom debian packages
  