### PR TITLE
Add RESIZE=yes param to shapefiles export

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,10 @@
-#Changelog
+# Changelog
 
 ## 1.48.1
 Released 2018-mm-dd
+
+Announcements:
+ * Added `RESIZE=yes` param to gdal shapefile driver, wich optimizes size of exported shapefiles [#462](https://github.com/CartoDB/CartoDB-SQL-API/pull/462)
 
 
 ## 1.48.0

--- a/app/models/formats/ogr.js
+++ b/app/models/formats/ogr.js
@@ -145,6 +145,7 @@ OgrFormat.prototype.toOGR = function(options, out_format, out_filename, callback
 
       var ogrargs = [
         '-f', out_format,
+        '-lco', 'RESIZE=YES',
         '-lco', 'ENCODING=UTF-8',
         '-lco', 'LINEFORMAT=CRLF',
         out_filename,


### PR DESCRIPTION
Add the parameter `RESIZE=yes` to gdal shapefile driver. This resizes
fields to their optimal size. See
http://www.gdal.org/drv_shapefile.html for details.

This is needed because some customers are having trouble exporting
shapefiles, then reimporting into ArcGIS.