### PR TITLE
Honor `batch_api_port` for Batch Queries

### DIFF
--- a/app/controllers/job_controller.js
+++ b/app/controllers/job_controller.js
@@ -99,7 +99,7 @@ function createJob (jobService) {
             user: res.locals.user,
             query: params.query,
             host: res.locals.userDbParams.host,
-            port: res.locals.userDbParams.port,
+            port: global.settings.db_batch_port || global.settings.db_port,
             pass: res.locals.userDbParams.pass,
             dbname: res.locals.userDbParams.dbname,
             dbuser: res.locals.userDbParams.user

--- a/app/controllers/job_controller.js
+++ b/app/controllers/job_controller.js
@@ -99,7 +99,7 @@ function createJob (jobService) {
             user: res.locals.user,
             query: params.query,
             host: res.locals.userDbParams.host,
-            port: global.settings.db_batch_port || global.settings.db_port,
+            port: global.settings.db_batch_port || res.locals.userDbParams.port,
             pass: res.locals.userDbParams.pass,
             dbname: res.locals.userDbParams.dbname,
             dbuser: res.locals.userDbParams.user


### PR DESCRIPTION
With the new `Auth API`, a job created with a specific `api-key` should be performed with the same credentials. Before Auth API, all jobs were executed with `master api-key` and used a custom port to bypass `pgbouncer`. After deploying the new Auth API, jobs store the connection params of the user and were saved with the generic `port` instead of the specific one for Batch Queries.