### PR TITLE
fix validatePGEntitiesAccess access

### DIFF
--- a/app/services/pg-entities-access-validator.js
+++ b/app/services/pg-entities-access-validator.js
@@ -20,7 +20,7 @@ const Validator = {
         let softValidationResult = true;
 
         if (!!affectedTables && affectedTables.tables) {
-            if (global.validatePGEntitiesAccess) {
+            if (global.settings.validatePGEntitiesAccess) {
                 hardValidationResult = this.hardValidation(affectedTables.tables);
             }
 

--- a/test/acceptance/pg-entities-access-validator.js
+++ b/test/acceptance/pg-entities-access-validator.js
@@ -26,7 +26,7 @@ describe('PG entities access validator', function () {
 
     describe('validatePGEntitiesAccess enabled', function() {
         before(function(){
-            global.validatePGEntitiesAccess = true;            
+            global.settings.validatePGEntitiesAccess = true;            
         });
 
         forbiddenQueries.forEach(query => {
@@ -42,7 +42,7 @@ describe('PG entities access validator', function () {
     
     describe('validatePGEntitiesAccess disabled', function() {
         before(function(){
-            global.validatePGEntitiesAccess = false;            
+            global.settings.validatePGEntitiesAccess = false;            
         });
         
         forbiddenQueries.forEach(query => {

--- a/test/unit/pg-entities-access-validator.test.js
+++ b/test/unit/pg-entities-access-validator.test.js
@@ -73,11 +73,11 @@ const fakeAffectedTablesTopologyKO = [
 
 describe('pg entities access validator with validatePGEntitiesAccess enabled', function () {
     before(function() {
-        global.validatePGEntitiesAccess = true;
+        global.settings.validatePGEntitiesAccess = true;
     });
 
     after(function() {
-        global.validatePGEntitiesAccess = false;
+        global.settings.validatePGEntitiesAccess = false;
     });
 
     it('validate function: bad parameters', function () {


### PR DESCRIPTION
I added an error in https://github.com/CartoDB/CartoDB-SQL-API/pull/478

As a result, the new validatePGEntitiesAccess is never used (and always works as `false`)