### PR TITLE
Making ratelimits configuration keys backwards compatible

### DIFF
--- a/app/middlewares/rate-limit.js
+++ b/app/middlewares/rate-limit.js
@@ -51,8 +51,10 @@ function rateLimit(userLimits, endpointGroup = null) {
 }
 
 function isRateLimitEnabled(endpointGroup) {
-    return global.settings.ratelimits.rateLimitsEnabled &&
+    return global.settings.ratelimits &&
+        global.settings.ratelimits.rateLimitsEnabled &&
         endpointGroup &&
+        global.settings.ratelimits.endpoints &&
         global.settings.ratelimits.endpoints[endpointGroup];
 }
 

--- a/app/server.js
+++ b/app/server.js
@@ -139,7 +139,7 @@ function App(statsClient) {
     
     const userLimitsServiceOptions = {
         limits: {
-            rateLimitsEnabled: global.settings.ratelimits.rateLimitsEnabled
+            rateLimitsEnabled: (global.settings.ratelimits && global.settings.ratelimits.rateLimitsEnabled) || false
         }
     };
     const userLimitsService = new UserLimitsService(metadataBackend, userLimitsServiceOptions);

--- a/test/acceptance/rate-limit.js
+++ b/test/acceptance/rate-limit.js
@@ -72,6 +72,10 @@ function assertRequest (status, limit, remaining, reset, retry, done = null) {
 
 describe('rate limit', function() {
     before(function() {
+        if (!global.settings.ratelimits) {
+            global.settings.ratelimits = {};
+            global.settings.ratelimits.endpoints = {};
+        }
         global.settings.ratelimits.rateLimitsEnabled = true;
         global.settings.ratelimits.endpoints.query = true;
         
@@ -85,6 +89,10 @@ describe('rate limit', function() {
     });
 
     after(function() {
+        if (!global.settings.ratelimits) {
+            global.settings.ratelimits = {};
+            global.settings.ratelimits.endpoints = {};
+        }
         global.settings.ratelimits.rateLimitsEnabled = false;
         global.settings.ratelimits.endpoints.query = false;
 


### PR DESCRIPTION
Fix: https://github.com/CartoDB/CartoDB-SQL-API/issues/484