### PR TITLE
Cancel copy to upon client disconnect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ test/test.log
 test/acceptance/oauth/venv/*
 coverage/
 npm-debug.log
+log/*.log
+yarn.lock

--- a/app/services/stream_copy.js
+++ b/app/services/stream_copy.js
@@ -34,8 +34,11 @@ module.exports = {
                         const runningClient = client;
                         const cancelingClient = new Client(runningClient.connectionParameters);
                         cancelingClient.cancel(runningClient, pgstream);
+
+                        const err = new Error('Connection closed by client');
                         pgstream.unpipe(res);
-                        done(new Error('Connection closed by client'));
+                        // see https://node-postgres.com/api/pool#release-err-error-
+                        done(err);
                         return cb(err);
                     }
                 })
@@ -45,7 +48,7 @@ module.exports = {
                 .on('error', err => {
                     if (!connectionClosedByClient) {
                         pgstream.unpipe(res);
-                        done(new Error('Connection closed by client'));
+                        done();
                         return cb(err);
                     }
                 })

--- a/app/services/stream_copy.js
+++ b/app/services/stream_copy.js
@@ -62,7 +62,7 @@ module.exports = {
                 .on('close', () => {
                     if (!requestEnded) {
                         const connection = client.connection;
-                        connection.sendCopyFail();
+                        connection.sendCopyFail('CARTO SQL API: Connection closed by client');
                         req.unpipe(pgstream);
                         return cb(new Error('Connection closed by client'));
                     }

--- a/app/services/stream_copy.js
+++ b/app/services/stream_copy.js
@@ -14,6 +14,21 @@ module.exports = {
                 return cb(err);
             }
 
+            let responseEnded = false;
+
+            res
+                .on('error', err => {
+                    pgstream.unpipe(res);
+                    return cb(err);
+                })
+                .on('close', () => {
+                    if (!responseEnded) {
+
+                        return cb(new Error('Connection closed by client'));
+                    }
+                })
+                .on('end', () => responseEnded = true);
+
             const copyToStream = copyTo(sql);
             const pgstream = client.query(copyToStream);
             pgstream

--- a/app/services/stream_copy.js
+++ b/app/services/stream_copy.js
@@ -37,7 +37,7 @@ module.exports = {
 
                         const err = new Error('Connection closed by client');
                         pgstream.unpipe(res);
-                        // see https://node-postgres.com/api/pool#release-err-error-
+                        // see https://node-postgres.com/api/pool#releasecallback
                         done(err);
                         return cb(err);
                     }
@@ -48,7 +48,7 @@ module.exports = {
                 .on('error', err => {
                     if (!connectionClosedByClient) {
                         pgstream.unpipe(res);
-                        done();
+                        done(err);
                         return cb(err);
                     }
                 })

--- a/test/acceptance/copy-endpoints.js
+++ b/test/acceptance/copy-endpoints.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const querystring = require('querystring');
 const assert = require('../support/assert');
 const os = require('os');
+const { Client } = require('pg');
 
 const StatsClient = require('../../app/stats/client');
 if (global.settings.statsd) {
@@ -18,6 +19,20 @@ const server = require('../../app/server')(statsClient);
 
 
 describe('copy-endpoints', function() {
+    before(function(done) {
+        const client = new Client({
+            user: 'postgres',
+            host: 'localhost',
+            database: 'cartodb_test_user_1_db',
+            port: 5432,
+        });
+        client.connect();
+        client.query('TRUNCATE copy_endpoints_test', (err/*, res */) => {
+            client.end();
+            done(err);
+        });
+    });
+
     it('should work with copyfrom endpoint', function(done){
         assert.response(server, {
             url: "/api/v1/sql/copyfrom?" + querystring.stringify({


### PR DESCRIPTION
Hey, I have this partial solution but it has a flaw: connections are not returned to the pg (node) pool (I'm wondering if they are in the case of the COPY FROM and CopyFail command).

How to test it:
1. Use a direct connection to PG: `module.exports.db_port  = '5432';` in config file.
1. Set `module.exports.db_pool_size = 5` in configs to a rather small number.
1. Perform 5  of `COPY TO` operations and cancel them (curl + `CTRL+C`).
1. Try to complete the 6th COPY TO.

Expected: the 6th operation takes an established connection from the pool and executes it. The COPY TO completes.

Actual: as there are no pg connections available in the pg pool, the 6th operation is enqueued waiting for one to be placed back in the pool, and curl eventually times out.

You can also see the connection/backends in the DB:
```
select pid, state, wait_event, wait_event_type, query from pg_stat_activity where query like 'COPY%';
  pid  | state | wait_event | wait_event_type |                          query                           
-------+-------+------------+-----------------+----------------------------------------------------------
 25020 | idle  | ClientRead | Client          | COPY nycpluto_all TO stdout WITH(FORMAT csv,HEADER true)
 25028 | idle  | ClientRead | Client          | COPY nycpluto_all TO stdout WITH(FORMAT csv,HEADER true)
 25037 | idle  | ClientRead | Client          | COPY nycpluto_all TO stdout WITH(FORMAT csv,HEADER true)
 25045 | idle  | ClientRead | Client          | COPY nycpluto_all TO stdout WITH(FORMAT csv,HEADER true)
 25056 | idle  | ClientRead | Client          | COPY nycpluto_all TO stdout WITH(FORMAT csv,HEADER true)
(5 rows)
```

keep in mind that normally those idle connection/backends can be reused (if node pg knows they are available).

I'd rather write tests for this, but to be honest I don't know how to write sane ones for such scenarios.