### PR TITLE
WIP: Return 'pgtype' and other field info in JSON return?

### DIFF
--- a/app/models/formats/pg/json.js
+++ b/app/models/formats/pg/json.js
@@ -44,8 +44,8 @@ JsonFormat.prototype.formatResultFields = function(flds) {
     var rv = { type: tname, pgtype: cname };
 
     if ( cname.match(/geometry|geography/) ) {
-        var typmodInfo = this.client.typeModInfo(f.dataTypeModifier);
-        _.extend(rv, typmodInfo);
+      var typmodInfo = this.client.typeModInfo(f.dataTypeModifier);
+      _.extend(rv, typmodInfo);
     }
     nfields[f.name] = rv
   }

--- a/app/models/formats/pg/json.js
+++ b/app/models/formats/pg/json.js
@@ -41,7 +41,13 @@ JsonFormat.prototype.formatResultFields = function(flds) {
         tname += '[]';
       }
     }
-    nfields[f.name] = { type: tname };
+    var rv = { type: tname, pgtype: cname };
+
+    if ( cname.match(/geometry|geography/) ) {
+        var typmodInfo = this.client.typeModInfo(f.dataTypeModifier);
+        _.extend(rv, typmodInfo);
+    }
+    nfields[f.name] = rv
   }
   return nfields;
 };


### PR DESCRIPTION
To address #498, a PoC that returns extra, more exact field type information, hopefully to make things easier for OGR in reading tables without needing full administrative api key access.