### PR TITLE
Use our patched node-pg-copy-streams

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -853,8 +853,8 @@
     },
     "pg-copy-streams": {
       "version": "1.2.0",
-      "from": "pg-copy-streams@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/pg-copy-streams/-/pg-copy-streams-1.2.0.tgz"
+      "from": "cartodb/node-pg-copy-streams#v1.2.0-carto.1",
+      "resolved": "git://github.com/cartodb/node-pg-copy-streams.git#d7e5c1383ff9b43890f2c37bc38cfed1afc2523f"
     },
     "pg-int8": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "node-statsd": "~0.0.7",
     "node-uuid": "^1.4.7",
     "oauth-client": "0.3.0",
-    "pg-copy-streams": "^1.2.0",
+    "pg-copy-streams": "cartodb/node-pg-copy-streams#v1.2.0-carto.1",
     "qs": "~6.2.1",
     "queue-async": "~1.0.7",
     "redis-mpool": "0.5.0",


### PR DESCRIPTION
The patch includes a performance improvement for the COPY TO. It can
eventually be removed in the PR to upstream is approved. See

https://github.com/brianc/node-pg-copy-streams/pull/70

and

https://github.com/CartoDB/node-pg-copy-streams/pull/1