### PR TITLE
Copy tests more deterministics

### DIFF
--- a/test/acceptance/copy-abort.js
+++ b/test/acceptance/copy-abort.js
@@ -43,7 +43,7 @@ function countInsertedRows (host, port, callback) {
     }, 1000);
 }
 
-describe.only('Cancel "copy to" commands', function () {
+describe('Cancel "copy to" commands', function () {
 
     beforeEach(function (done) {
         this.listener = server.listen(0, '127.0.0.1');

--- a/test/acceptance/copy-abort.js
+++ b/test/acceptance/copy-abort.js
@@ -1,0 +1,229 @@
+const querystring = require('querystring');
+const StatsClient = require('../../app/stats/client');
+const statsClient = StatsClient.getInstance(global.settings.statsd);
+const server = require('../../app/server')(statsClient);
+const request = require('request');
+const assert = require('assert');
+
+const copyQuery = `COPY (
+    INSERT INTO copy_to_test
+    SELECT updated_at
+    FROM generate_series('1984-06-14 01:00:00'::timestamp, '2018-06-14 01:00:00'::timestamp, '1 hour'::interval) updated_at
+    RETURNING updated_at
+) TO STDOUT`;
+
+const createTableQuery = `CREATE TABLE copy_to_test AS
+    (SELECT '2018-06-15 14:49:05.126415+00'::timestamp AS updated_at)`;
+
+const dropTableQuery = `DROP TABLE copy_to_test`;
+
+const countQuery = `SELECT count(1) as count FROM copy_to_test`;
+
+function countInsertedRows (host, port, callback) {
+    setTimeout(function () {
+        const count = querystring.stringify({ q: countQuery, api_key: 1234 });
+
+        const options = {
+            url: `http://${host}:${port}/api/v1/sql?${count}`,
+            headers: { host: 'vizzuality.cartodb.com' },
+            method: 'GET'
+        };
+
+        request(options, function (err, res, body) {
+            if (err) {
+                return callback(err);
+            }
+
+            assert.equal(res.statusCode, 200);
+
+            const result = JSON.parse(body)
+
+            callback(null, result);
+        });
+    }, 1000);
+}
+
+describe.only('Cancel "copy to" commands', function () {
+
+    beforeEach(function (done) {
+        this.listener = server.listen(0, '127.0.0.1');
+
+        this.listener.on('error', done);
+
+        this.listener.on('listening', () => {
+            const { address, port } = this.listener.address();
+
+            this.host = address;
+            this.port = port;
+
+            done();
+        });
+    });
+
+    beforeEach(function (done) {
+        const { host, port } = this;
+
+        const createTable = querystring.stringify({ q: createTableQuery, api_key: 1234});
+
+        const createTableOptions = {
+            url: `http://${host}:${port}/api/v1/sql?${createTable}`,
+            headers: { host: 'vizzuality.cartodb.com' },
+            method: 'GET'
+        };
+
+        request(createTableOptions, function (err, res) {
+            if (err) {
+                return done(err);
+            }
+
+            assert.equal(res.statusCode, 200);
+
+            done();
+        });
+    });
+
+    afterEach(function (done) {
+        const { host, port } = this;
+
+        const dropTable = querystring.stringify({ q: dropTableQuery, api_key: 1234 });
+
+        const createTableOptions = {
+            url: `http://${host}:${port}/api/v1/sql?${dropTable}`,
+            headers: { host: 'vizzuality.cartodb.com' },
+            method: 'GET'
+        };
+
+        request(createTableOptions, function (err, res) {
+            if (err) {
+                return done(err);
+            }
+
+            assert.equal(res.statusCode, 200);
+
+            done();
+        });
+    });
+
+    afterEach(function (done) {
+        this.listener.close(done);
+    });
+
+    it('abort on response', function (done) {
+        const { host, port } = this;
+
+        const copy = querystring.stringify({ q: copyQuery, api_key: 1234 });
+
+        const options = {
+            url: `http://${host}:${port}/api/v1/sql/copyto?${copy}`,
+            headers: { host: 'vizzuality.cartodb.com' },
+            method: 'GET'
+        };
+
+        const req = request(options);
+
+        req.on('response', function () {
+            req.abort();
+
+            countInsertedRows(host, port, function (err, result) {
+                if (err) {
+                    return done(err);
+                }
+
+                assert.equal(result.rows[0].count, 1);
+
+                done();
+            });
+        });
+    });
+
+    it('abort on data', function (done) {
+        const { host, port } = this;
+
+        const copy = querystring.stringify({ q: copyQuery, api_key: 1234 });
+
+        const options = {
+            url: `http://${host}:${port}/api/v1/sql/copyto?${copy}`,
+            headers: { host: 'vizzuality.cartodb.com' },
+            method: 'GET'
+        };
+
+        const req = request(options);
+
+        req.once('data', function () {
+            req.abort();
+
+            countInsertedRows(host, port, function (err, result) {
+                if (err) {
+                    return done(err);
+                }
+
+                assert.equal(result.rows[0].count, 1);
+
+                done();
+            });
+        });
+    });
+
+
+    it('destroy on data', function (done) {
+        const { host, port } = this;
+
+        const copy = querystring.stringify({ q: copyQuery, api_key: 1234 });
+
+        const options = {
+            url: `http://${host}:${port}/api/v1/sql/copyto?${copy}`,
+            headers: { host: 'vizzuality.cartodb.com' },
+            method: 'GET'
+        };
+
+        const req = request(options);
+
+        let response;
+
+        req.on('response', function (res) {
+            response = res;
+        });
+
+        req.once('data', function () {
+            response.destroy();
+
+            countInsertedRows(host, port, function (err, result) {
+                if (err) {
+                    return done(err);
+                }
+
+                assert.equal(result.rows[0].count, 1);
+
+                done();
+            });
+        });
+    });
+
+    it('destroy on response', function (done) {
+        const { host, port } = this;
+
+        const copy = querystring.stringify({ q: copyQuery, api_key: 1234 });
+
+        const options = {
+            url: `http://${host}:${port}/api/v1/sql/copyto?${copy}`,
+            headers: { host: 'vizzuality.cartodb.com' },
+            method: 'GET'
+        };
+
+        const req = request(options);
+
+        req.on('response', function (response) {
+            response.destroy();
+
+            countInsertedRows(host, port, function (err, result) {
+                if (err) {
+                    return done(err);
+                }
+
+                assert.equal(result.rows[0].count, 1);
+
+                done();
+            });
+        });
+    });
+});

--- a/test/acceptance/copy-abort.js
+++ b/test/acceptance/copy-abort.js
@@ -8,7 +8,11 @@ const assert = require('assert');
 const copyQuery = `COPY (
     INSERT INTO copy_to_test
     SELECT updated_at
-    FROM generate_series('1984-06-14 01:00:00'::timestamp, '2018-06-14 01:00:00'::timestamp, '1 hour'::interval) updated_at
+    FROM generate_series(
+        '1984-06-14 01:00:00'::timestamp,
+        '2018-06-14 01:00:00'::timestamp,
+        '1 hour'::interval
+    ) updated_at
     RETURNING updated_at
 ) TO STDOUT`;
 
@@ -35,9 +39,7 @@ function countInsertedRows (host, port, callback) {
             }
 
             assert.equal(res.statusCode, 200);
-
-            const result = JSON.parse(body)
-
+            const result = JSON.parse(body);
             callback(null, result);
         });
     }, 1000);

--- a/test/acceptance/copy-abort.js
+++ b/test/acceptance/copy-abort.js
@@ -89,13 +89,13 @@ describe('Cancel "copy to" commands', function () {
 
         const dropTable = querystring.stringify({ q: dropTableQuery, api_key: 1234 });
 
-        const createTableOptions = {
+        const dropTableOptions = {
             url: `http://${host}:${port}/api/v1/sql?${dropTable}`,
             headers: { host: 'vizzuality.cartodb.com' },
             method: 'GET'
         };
 
-        request(createTableOptions, function (err, res) {
+        request(dropTableOptions, function (err, res) {
             if (err) {
                 return done(err);
             }

--- a/test/acceptance/copy-abort.js
+++ b/test/acceptance/copy-abort.js
@@ -42,7 +42,7 @@ function countInsertedRows (host, port, callback) {
             const result = JSON.parse(body);
             callback(null, result);
         });
-    }, 1000);
+    }, 100);
 }
 
 describe('Cancel "copy to" commands', function () {

--- a/test/acceptance/copy-endpoints.js
+++ b/test/acceptance/copy-endpoints.js
@@ -19,22 +19,28 @@ const statsClient = StatsClient.getInstance(global.settings.statsd);
 const server = require('../../app/server')(statsClient);
 
 
-describe('copy-endpoints', function() {
-    describe('general', function() {
-        before(function(done) {
-            const client = new Client({
-                user: 'postgres',
-                host: 'localhost',
-                database: 'cartodb_test_user_1_db',
-                port: 5432,
-            });
-            client.connect();
-            client.query('TRUNCATE copy_endpoints_test', (err/*, res */) => {
-                client.end();
-                done(err);
-            });
+describe.only('copy-endpoints', function() {
+    before(function() {
+        this.client = new Client({
+            user: 'postgres',
+            host: 'localhost',
+            database: 'cartodb_test_user_1_db',
+            port: 5432,
         });
-    
+        this.client.connect();
+    });
+
+    after(function() {
+        this.client.end();
+    })
+
+    afterEach(function (done) {
+        this.client.query('TRUNCATE copy_endpoints_test', err => {
+            done(err);
+        });
+    });
+
+    describe('general', function() {
         it('should work with copyfrom endpoint', function(done){
             assert.response(server, {
                 url: "/api/v1/sql/copyfrom?" + querystring.stringify({
@@ -47,11 +53,11 @@ describe('copy-endpoints', function() {
                 assert.ifError(err);
                 const response = JSON.parse(res.body);
                 assert.equal(!!response.time, true);
-                assert.strictEqual(response.total_rows, 6);    
+                assert.strictEqual(response.total_rows, 6);
                 done();
             });
         });
-    
+
         it('should fail with copyfrom endpoint and unexisting table', function(done){
             assert.response(server, {
                 url: "/api/v1/sql/copyfrom?" + querystring.stringify({
@@ -63,7 +69,7 @@ describe('copy-endpoints', function() {
             },{}, function(err, res) {
                 assert.ifError(err);
                 assert.deepEqual(
-                    JSON.parse(res.body), 
+                    JSON.parse(res.body),
                     {
                         error:['relation \"unexisting_table\" does not exist']
                     }
@@ -71,7 +77,7 @@ describe('copy-endpoints', function() {
                 done();
             });
         });
-    
+
         it('should fail with copyfrom endpoint and without csv', function(done){
             assert.response(server, {
                 url: "/api/v1/sql/copyfrom?" + querystring.stringify({
@@ -82,7 +88,7 @@ describe('copy-endpoints', function() {
             },{}, function(err, res) {
                 assert.ifError(err);
                 assert.deepEqual(
-                    JSON.parse(res.body), 
+                    JSON.parse(res.body),
                     {
                         error:['No rows copied']
                     }
@@ -90,17 +96,17 @@ describe('copy-endpoints', function() {
                 done();
             });
         });
-    
+
         it('should fail with copyfrom endpoint and without q', function(done){
             assert.response(server, {
                 url: "/api/v1/sql/copyfrom",
-                data: fs.createReadStream(__dirname + '/../support/csv/copy_test_table.csv'),            
+                data: fs.createReadStream(__dirname + '/../support/csv/copy_test_table.csv'),
                 headers: {host: 'vizzuality.cartodb.com'},
                 method: 'POST'
             },{}, function(err, res) {
                 assert.ifError(err);
                 assert.deepEqual(
-                    JSON.parse(res.body), 
+                    JSON.parse(res.body),
                     {
                         error:["SQL is missing"]
                     }
@@ -108,7 +114,7 @@ describe('copy-endpoints', function() {
                 done();
             });
         });
-    
+
         it('should work with copyto endpoint', function(done){
             assert.response(server, {
                 url: "/api/v1/sql/copyto?" + querystring.stringify({
@@ -120,17 +126,17 @@ describe('copy-endpoints', function() {
             },{}, function(err, res) {
                 assert.ifError(err);
                 assert.strictEqual(
-                    res.body, 
+                    res.body,
                     '11\tPaul\t10\n12\tPeter\t10\n13\tMatthew\t10\n14\t\\N\t10\n15\tJames\t10\n16\tJohn\t10\n'
                 );
-    
+
                 assert.equal(res.headers['content-disposition'], 'attachment; filename=%2Ftmp%2Foutput.dmp');
                 assert.equal(res.headers['content-type'], 'application/octet-stream');
-    
+
                 done();
             });
         });
-    
+
         it('should fail with copyto endpoint and without sql', function(done){
             assert.response(server, {
                 url: "/api/v1/sql/copyto?" + querystring.stringify({
@@ -141,7 +147,7 @@ describe('copy-endpoints', function() {
             },{}, function(err, res) {
                 assert.ifError(err);
                 assert.deepEqual(
-                    JSON.parse(res.body), 
+                    JSON.parse(res.body),
                     {
                         error:["SQL is missing"]
                     }
@@ -149,15 +155,15 @@ describe('copy-endpoints', function() {
                 done();
             });
         });
-    
+
         it('should work with copyfrom and gzip', function(done){
             assert.response(server, {
                 url: "/api/v1/sql/copyfrom?" + querystring.stringify({
-                    q: "COPY copy_endpoints_test2 (id, name) FROM STDIN WITH (FORMAT CSV, DELIMITER ',', HEADER true)"
+                    q: "COPY copy_endpoints_test (id, name) FROM STDIN WITH (FORMAT CSV, DELIMITER ',', HEADER true)"
                 }),
                 data: fs.createReadStream(__dirname + '/../support/csv/copy_test_table.csv.gz'),
                 headers: {
-                    host: 'vizzuality.cartodb.com', 
+                    host: 'vizzuality.cartodb.com',
                     'content-encoding': 'gzip'
                 },
                 method: 'POST'
@@ -169,11 +175,11 @@ describe('copy-endpoints', function() {
                 done();
             });
         });
-    
+
     });
-    
-    
-    describe('timeout', function() {       
+
+
+    describe('timeout', function() {
         it('should fail with copyfrom and timeout', function(done){
             assert.response(server, {
                 url: '/api/v1/sql?q=set statement_timeout = 10',
@@ -184,7 +190,7 @@ describe('copy-endpoints', function() {
                 assert.ifError(err);
                 assert.response(server, {
                     url: "/api/v1/sql/copyfrom?" + querystring.stringify({
-                        q: `COPY copy_endpoints_test (id, name) 
+                        q: `COPY copy_endpoints_test (id, name)
                             FROM STDIN WITH (FORMAT CSV, DELIMITER ',', HEADER true)`
                     }),
                     data: fs.createReadStream(__dirname + '/../support/csv/copy_test_table.csv'),
@@ -204,8 +210,8 @@ describe('copy-endpoints', function() {
                         context: 'limit',
                         detail: 'datasource'
                     });
-        
-                    
+
+
                     assert.response(server, {
                         url: "/api/v1/sql?q=set statement_timeout = 2000",
                         headers: {host: 'vizzuality.cartodb.com'},
@@ -215,7 +221,7 @@ describe('copy-endpoints', function() {
                 });
             });
         });
-    
+
         it('should fail with copyto and timeout', function(done){
             assert.response(server, {
                 url: '/api/v1/sql?q=set statement_timeout = 20',
@@ -240,7 +246,7 @@ describe('copy-endpoints', function() {
                     };
                     const expectedError = res.body.substring(res.body.length - JSON.stringify(error).length);
                     assert.deepEqual(JSON.parse(expectedError), error);
-                    
+
                     assert.response(server, {
                         url: "/api/v1/sql?q=set statement_timeout = 2000",
                         headers: {host: 'vizzuality.cartodb.com'},
@@ -251,24 +257,24 @@ describe('copy-endpoints', function() {
             });
         });
     });
-    
-    
+
+
     describe('db connections', function() {
         before(function() {
             this.db_pool_size = global.settings.db_pool_size;
             global.settings.db_pool_size = 1;
         });
-    
+
         after(function() {
             global.settings.db_pool_size = this.db_pool_size;
         });
-    
+
         it('copyfrom', function(done) {
             function doCopyFrom() {
                 return new Promise(resolve => {
                     assert.response(server, {
                         url: "/api/v1/sql/copyfrom?" + querystring.stringify({
-                            q: `COPY copy_endpoints_test (id, name) 
+                            q: `COPY copy_endpoints_test (id, name)
                                 FROM STDIN WITH (FORMAT CSV, DELIMITER ',', HEADER true)`
                         }),
                         data: fs.createReadStream(__dirname + '/../support/csv/copy_test_table.csv'),
@@ -282,12 +288,12 @@ describe('copy-endpoints', function() {
                     });
                 });
             }
-    
+
             Promise.all([doCopyFrom(), doCopyFrom(), doCopyFrom()]).then(function() {
                 done();
             });
         });
-    
+
         it('copyto', function(done) {
             function doCopyTo() {
                 return new Promise(resolve => {
@@ -305,27 +311,27 @@ describe('copy-endpoints', function() {
                     });
                 });
             }
-    
+
             Promise.all([doCopyTo(), doCopyTo(), doCopyTo()]).then(function() {
                 done();
             });
         });
     });
-    
+
     describe('client disconnection', function() {
         // Give it enough time to connect and issue the query
         // but not too much so as to disconnect in the middle of the query.
         const CLIENT_DISCONNECT_TIMEOUT = 10;
-    
+
         before(function() {
             this.db_pool_size = global.settings.db_pool_size;
             global.settings.db_pool_size = 1;
         });
-    
+
         after(function() {
             global.settings.db_pool_size = this.db_pool_size;
         });
-    
+
         var assertCanReuseConnection = function (done) {
             assert.response(server, {
                 url: '/api/v1/sql?' + querystring.stringify({
@@ -339,7 +345,7 @@ describe('copy-endpoints', function() {
                 done();
             });
         };
-    
+
         it('COPY TO returns the connection to the pool if the client disconnects', function(done) {
             const listener = server.listen(0, '127.0.0.1');
 
@@ -367,7 +373,7 @@ describe('copy-endpoints', function() {
                 });
             });
         });
-    
+
         it('COPY FROM returns the connection to the pool if the client disconnects', function(done) {
             const listener = server.listen(0, '127.0.0.1');
 
@@ -394,6 +400,6 @@ describe('copy-endpoints', function() {
                 }, CLIENT_DISCONNECT_TIMEOUT);
             });
         });
-    
+
     });
 });

--- a/test/acceptance/copy-endpoints.js
+++ b/test/acceptance/copy-endpoints.js
@@ -343,7 +343,7 @@ describe('copy-endpoints', function() {
     describe('client disconnection', function() {
         // Give it enough time to connect and issue the query
         // but not too much so as to disconnect in the middle of the query.
-        const CLIENT_DISCONNECT_TIMEOUT = 10;
+        const CLIENT_DISCONNECT_TIMEOUT = 100;
 
         before(function() {
             this.db_pool_size = global.settings.db_pool_size;

--- a/test/acceptance/copy-endpoints.js
+++ b/test/acceptance/copy-endpoints.js
@@ -354,6 +354,20 @@ describe('copy-endpoints', function() {
             global.settings.db_pool_size = this.db_pool_size;
         });
 
+        const assertCanReuseConnection = function (done) {
+            assert.response(server, {
+                url: '/api/v1/sql?' + querystring.stringify({
+                    q: 'SELECT 1',
+                }),
+                headers: { host: 'vizzuality.cartodb.com' },
+                method: 'GET'
+            }, {}, function(err, res) {
+                assert.ifError(err);
+                assert.ok(res.statusCode === 200);
+                done();
+            });
+        };
+
         const assertCanReuseCanceledConnection = function (done) {
             assert.response(server, {
                 url: '/api/v1/sql?' + querystring.stringify({
@@ -392,7 +406,7 @@ describe('copy-endpoints', function() {
                 req.once('data', () => req.abort());
                 req.on('response', response => {
                     response.on('end', () => {
-                        assertCanReuseCanceledConnection(done);
+                        assertCanReuseConnection(done);
                     });
                 });
             });

--- a/test/acceptance/copy-endpoints.js
+++ b/test/acceptance/copy-endpoints.js
@@ -32,7 +32,7 @@ describe.only('copy-endpoints', function() {
 
     after(function() {
         this.client.end();
-    });
+    })
 
     afterEach(function (done) {
         this.client.query('TRUNCATE copy_endpoints_test', err => {

--- a/test/support/sql/test.sql
+++ b/test/support/sql/test.sql
@@ -226,12 +226,3 @@ CREATE TABLE copy_endpoints_test (
 );
 GRANT ALL ON TABLE copy_endpoints_test TO :TESTUSER;
 GRANT ALL ON TABLE copy_endpoints_test TO :PUBLICUSER;
-
-DROP TABLE IF EXISTS copy_endpoints_test2;
-CREATE TABLE copy_endpoints_test2 (
-    id integer,
-    name text,
-    age integer default 10
-);
-GRANT ALL ON TABLE copy_endpoints_test2 TO :TESTUSER;
-GRANT ALL ON TABLE copy_endpoints_test2 TO :PUBLICUSER;


### PR DESCRIPTION
In order to get it, the idea (by @dgaubert) was:
- copy to: use a query with an insert and returning the inserted rows. If the copy to is canceled, the rows should not be in the database
- in copy form: the same idea: if the copy form query is canceled the rows should not be in the database

Other improvements:
- Ensuring the copy tests are independent
