### PR TITLE
Improve sql timeout error message

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 ## 2.1.1
 Released 2018-mm-dd
 
+Announcements:
+  * Improve error message when the DB query is over the user's limits
 
 ## 2.1.0
 Released 2018-06-13

--- a/app/services/error_handler_factory.js
+++ b/app/services/error_handler_factory.js
@@ -18,7 +18,7 @@ function isTimeoutError(err) {
 
 function createTimeoutError() {
     return new ErrorHandler({
-        message: 'You are over platform\'s limits. Please contact us to know more details.' +
+        message: 'You are over platform\'s limits. Please contact us to know more details. ' +
                  'SQL query timeout expired error.',
         context: 'limit',
         detail: 'datasource',

--- a/app/services/error_handler_factory.js
+++ b/app/services/error_handler_factory.js
@@ -18,7 +18,8 @@ function isTimeoutError(err) {
 
 function createTimeoutError() {
     return new ErrorHandler({
-        message: 'You are over platform\'s limits. Please contact us to know more details',
+        message: `You are over platform\'s limits. Please contact us to know more details. 
+                  SQL query timeout expired error.`,
         context: 'limit',
         detail: 'datasource',
         http_status: 429

--- a/app/services/error_handler_factory.js
+++ b/app/services/error_handler_factory.js
@@ -18,8 +18,8 @@ function isTimeoutError(err) {
 
 function createTimeoutError() {
     return new ErrorHandler({
-        message: 'You are over platform\'s limits. Please contact us to know more details. ' +
-                 'SQL query timeout expired error.',
+        message: 'You are over platform\'s limits: SQL query timeout error.' +
+                 ' Refactor your query before running again or contact CARTO support for more details.',
         context: 'limit',
         detail: 'datasource',
         http_status: 429

--- a/app/services/error_handler_factory.js
+++ b/app/services/error_handler_factory.js
@@ -18,8 +18,8 @@ function isTimeoutError(err) {
 
 function createTimeoutError() {
     return new ErrorHandler({
-        message: `You are over platform\'s limits. Please contact us to know more details. 
-                  SQL query timeout expired error.`,
+        message: 'You are over platform\'s limits. Please contact us to know more details.' +
+                 'SQL query timeout expired error.',
         context: 'limit',
         detail: 'datasource',
         http_status: 429

--- a/test/acceptance/app.test.js
+++ b/test/acceptance/app.test.js
@@ -791,8 +791,8 @@ it('GET with callback must return 200 status error even if it is an error', func
                 var error = JSON.parse(res.body);
                 assert.deepEqual(error, {
                     error: [
-                        'You are over platform\'s limits. Please contact us to know more details. ' +
-                        'SQL query timeout expired error.'
+                        'You are over platform\'s limits: SQL query timeout error.' +
+                        ' Refactor your query before running again or contact CARTO support for more details.',
                     ],
                     context: 'limit',
                     detail: 'datasource'
@@ -818,8 +818,8 @@ it('GET with callback must return 200 status error even if it is an error', func
                 var error = JSON.parse(res.body);
                 assert.deepEqual(error, {
                     error: [
-                        'You are over platform\'s limits. Please contact us to know more details. ' +
-                        'SQL query timeout expired error.'
+                        'You are over platform\'s limits: SQL query timeout error.' +
+                        ' Refactor your query before running again or contact CARTO support for more details.',
                     ],
                     context: 'limit',
                     detail: 'datasource'

--- a/test/acceptance/app.test.js
+++ b/test/acceptance/app.test.js
@@ -791,7 +791,8 @@ it('GET with callback must return 200 status error even if it is an error', func
                 var error = JSON.parse(res.body);
                 assert.deepEqual(error, {
                     error: [
-                        'You are over platform\'s limits. Please contact us to know more details'
+                        'You are over platform\'s limits. Please contact us to know more details. ' +
+                        'SQL query timeout expired error.'
                     ],
                     context: 'limit',
                     detail: 'datasource'
@@ -817,7 +818,8 @@ it('GET with callback must return 200 status error even if it is an error', func
                 var error = JSON.parse(res.body);
                 assert.deepEqual(error, {
                     error: [
-                        'You are over platform\'s limits. Please contact us to know more details'
+                        'You are over platform\'s limits. Please contact us to know more details. ' +
+                        'SQL query timeout expired error.'
                     ],
                     context: 'limit',
                     detail: 'datasource'

--- a/test/acceptance/copy-endpoints.js
+++ b/test/acceptance/copy-endpoints.js
@@ -216,7 +216,8 @@ describe('copy-endpoints', function() {
                     assert.ifError(err);
                     assert.deepEqual(JSON.parse(res.body), {
                         error: [
-                            'You are over platform\'s limits. Please contact us to know more details'
+                            'You are over platform\'s limits. Please contact us to know more details. ' +
+                            'SQL query timeout expired error.'
                         ],
                         context: 'limit',
                         detail: 'datasource'
@@ -251,7 +252,8 @@ describe('copy-endpoints', function() {
                 },{}, function(err, res) {
                     assert.ifError(err);
                     const error = {
-                        error:["You are over platform's limits. Please contact us to know more details"],
+                        error: ['You are over platform\'s limits. Please contact us to know more details. ' +
+                                'SQL query timeout expired error.'],
                         context:"limit",
                         detail:"datasource"
                     };

--- a/test/acceptance/copy-endpoints.js
+++ b/test/acceptance/copy-endpoints.js
@@ -216,8 +216,8 @@ describe('copy-endpoints', function() {
                     assert.ifError(err);
                     assert.deepEqual(JSON.parse(res.body), {
                         error: [
-                            'You are over platform\'s limits. Please contact us to know more details. ' +
-                            'SQL query timeout expired error.'
+                            'You are over platform\'s limits: SQL query timeout error.' +
+                            ' Refactor your query before running again or contact CARTO support for more details.',
                         ],
                         context: 'limit',
                         detail: 'datasource'
@@ -252,8 +252,8 @@ describe('copy-endpoints', function() {
                 },{}, function(err, res) {
                     assert.ifError(err);
                     const error = {
-                        error: ['You are over platform\'s limits. Please contact us to know more details. ' +
-                                'SQL query timeout expired error.'],
+                        error: ['You are over platform\'s limits: SQL query timeout error.' +
+                            ' Refactor your query before running again or contact CARTO support for more details.',],
                         context:"limit",
                         detail:"datasource"
                     };

--- a/test/acceptance/export/timeout.js
+++ b/test/acceptance/export/timeout.js
@@ -98,7 +98,8 @@ describe('timeout', function () {
 
                     assert.deepEqual(res, {
                         error: [
-                            'You are over platform\'s limits. Please contact us to know more details'
+                            'You are over platform\'s limits. Please contact us to know more details. ' +
+                            'SQL query timeout expired error.'
                         ],
                         context: 'limit',
                         detail: 'datasource'
@@ -180,7 +181,8 @@ describe('timeout', function () {
 
                     assert.deepEqual(res, {
                         error: [
-                            'You are over platform\'s limits. Please contact us to know more details'
+                            'You are over platform\'s limits. Please contact us to know more details. ' +
+                            'SQL query timeout expired error.'
                         ],
                         context: 'limit',
                         detail: 'datasource'

--- a/test/acceptance/export/timeout.js
+++ b/test/acceptance/export/timeout.js
@@ -98,8 +98,8 @@ describe('timeout', function () {
 
                     assert.deepEqual(res, {
                         error: [
-                            'You are over platform\'s limits. Please contact us to know more details. ' +
-                            'SQL query timeout expired error.'
+                            'You are over platform\'s limits: SQL query timeout error.' +
+                            ' Refactor your query before running again or contact CARTO support for more details.',
                         ],
                         context: 'limit',
                         detail: 'datasource'
@@ -181,8 +181,8 @@ describe('timeout', function () {
 
                     assert.deepEqual(res, {
                         error: [
-                            'You are over platform\'s limits. Please contact us to know more details. ' +
-                            'SQL query timeout expired error.'
+                            'You are over platform\'s limits: SQL query timeout error.' +
+                            ' Refactor your query before running again or contact CARTO support for more details.',
                         ],
                         context: 'limit',
                         detail: 'datasource'

--- a/test/unit/error_handler_factory.test.js
+++ b/test/unit/error_handler_factory.test.js
@@ -44,7 +44,8 @@ describe('error-handler-factory', function () {
         const error = new Error('statement timeout');
         const errorHandler = errorHandlerFactory(error);
         const expectedError = new ErrorHandler({
-            message: 'You are over platform\'s limits. Please contact us to know more details',
+            message: 'You are over platform\'s limits. Please contact us to know more details. ' +
+                     'SQL query timeout expired error.',
             context: 'limit',
             detail: 'datasource',
             http_status: 429

--- a/test/unit/error_handler_factory.test.js
+++ b/test/unit/error_handler_factory.test.js
@@ -44,8 +44,8 @@ describe('error-handler-factory', function () {
         const error = new Error('statement timeout');
         const errorHandler = errorHandlerFactory(error);
         const expectedError = new ErrorHandler({
-            message: 'You are over platform\'s limits. Please contact us to know more details. ' +
-                     'SQL query timeout expired error.',
+            message: 'You are over platform\'s limits: SQL query timeout error.' +
+                ' Refactor your query before running again or contact CARTO support for more details.',
             context: 'limit',
             detail: 'datasource',
             http_status: 429


### PR DESCRIPTION
closes #511

When a DB timeout error arises caused by our `limits system`, the user should be aware of the actual error reason. Currently, the API responses with a cryptic 429 http error:

```json
{
    "error": [
        "You are over platform's limits. Please contact us to know more details."
    ],
    "context": "limit",
    "detail": "datasource"
}
```

This PR simply adds ` SQL query timeout expired error.` to the error message. This way, we don't break current users implementations (_hello frontenders!_):

```json
{
    "error": [
        "You are over platform's limits. Please contact us to know more details. SQL query timeout expired error."
    ],
    "context": "limit",
    "detail": "datasource"
}
```
