### PR TITLE
Fix typo in example: s/query/q/

### DIFF
--- a/docs/reference/swagger.yaml
+++ b/docs/reference/swagger.yaml
@@ -146,7 +146,7 @@ paths:
         - lang: Curl
           source: |
             curl -X POST -H "Content-Type: application/json" -d '{ \
-              "query": "SELECT count(*) FROM cities", \
+              "q": "SELECT count(*) FROM cities", \
               "filename": "number_of_cities.json" \
             }' "https://username.carto.com/api/v2/sql"
 


### PR DESCRIPTION
For the endpoint `api/v2/sql` the parameter to pass queries is `q`.
It is important to fix because it is in the SQL API front page. Thanks
@ibrahimmenem for spotting it.