### PR TITLE
Allow tests to be executed against pgbouncer

### DIFF
--- a/test/prepare_db.sh
+++ b/test/prepare_db.sh
@@ -107,7 +107,7 @@ if test x"$PREPARE_PGSQL" = xyes; then
       sed "s/:PUBLICPASS/${PUBLICPASS}/" |
       sed "s/:TESTUSER/${TESTUSER}/" |
       sed "s/:TESTPASS/${TESTPASS}/" |
-      PGOPTIONS='--client-min-messages=WARNING' psql -q -v ON_ERROR_STOP=1 ${TEST_DB} > /dev/null || exit 1
+      psql -q -v ON_ERROR_STOP=1 ${TEST_DB} > /dev/null || exit 1
   done
 
 fi


### PR DESCRIPTION
pgbouncer does not support the `--client-min-messages` option. Actually
it fails connections if used like that with this somewhat cryptic
message:

```
psql: ERROR:  Unsupported startup parameter: options
```

In order to be able to execute tests against pgbouncer port (which is
desirable IMO), we either need to remove that option (with little to no
impact) or change the lines above to choose the batch API port from the
config.

Mind that this affects just test setup.