### PR TITLE
Copy limits rework

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,15 @@
 # Changelog
 
-## 2.1.1
+## 2.2.0
 Released 2018-mm-dd
 
 Announcements:
   * Improve error message when the DB query is over the user's limits
   * Updated cartodb-redis to 2.0.1
+  * Modify the COPY query limits:
+      - Instead of the generic timeout, it now uses a 5h timeout.
+      - For COPY FROM, the limit is size-based, up to the remaining DB quota
+      - The largest COPY FROM that can be made in a single POST request is limited to 2GB
 
 
 ## 2.1.0

--- a/app/controllers/copy_controller.js
+++ b/app/controllers/copy_controller.js
@@ -131,16 +131,14 @@ function handleCopyFrom (logger) {
                     if(metrics.size > dbRemainingQuota) {
                         const quotaError = new Error('DB Quota exceeded');
                         metrics.end(null, quotaError);
-                        req.unpipe(pgstream);
-                        return next(quotaError);
+                        pgstream.emit('error', quotaError);
                     }
                     if((metrics.gzipSize || metrics.size) > COPY_FROM_MAX_POST_SIZE) {
                         const maxPostSizeError = new Error(
                             `COPY FROM maximum POST size of ${COPY_FROM_MAX_POST_SIZE_PRETTY} exceeded`
                         );
                         metrics.end(null, maxPostSizeError);
-                        req.unpipe(pgstream);
-                        return next(maxPostSizeError);
+                        pgstream.emit('error', maxPostSizeError);
                     }
                 })
                 .pipe(pgstream)

--- a/app/controllers/copy_controller.js
+++ b/app/controllers/copy_controller.js
@@ -126,6 +126,8 @@ function handleCopyFrom (logger) {
                 .on('data', data => {
                     metrics.addSize(data.length);
                     if(metrics.size > dbRemainingQuota) {
+                        metrics.end(null, err);
+                        req.unpipe(pgstream);
                         return next(new Error('DB Quota exceeded'));
                     }
                 })

--- a/app/controllers/copy_controller.js
+++ b/app/controllers/copy_controller.js
@@ -6,6 +6,7 @@ const authorizationMiddleware = require('../middlewares/authorization');
 const connectionParamsMiddleware = require('../middlewares/connection-params');
 const { initializeProfilerMiddleware } = require('../middlewares/profiler');
 const rateLimitsMiddleware = require('../middlewares/rate-limit');
+const dbQuotaMiddleware = require('../middlewares/db-quota');
 const { RATE_LIMIT_ENDPOINTS_GROUPS } = rateLimitsMiddleware;
 const errorHandlerFactory = require('../services/error_handler_factory');
 const StreamCopy = require('../services/stream_copy');
@@ -31,6 +32,7 @@ CopyController.prototype.route = function (app) {
             authorizationMiddleware(this.metadataBackend),
             connectionParamsMiddleware(this.userDatabaseService),
             validateCopyQuery(),
+            dbQuotaMiddleware(),
             handleCopyFrom(this.logger),
             errorHandler(),
             errorMiddleware()

--- a/app/controllers/copy_controller.js
+++ b/app/controllers/copy_controller.js
@@ -130,14 +130,12 @@ function handleCopyFrom (logger) {
 
                     if(metrics.size > dbRemainingQuota) {
                         const quotaError = new Error('DB Quota exceeded');
-                        metrics.end(null, quotaError);
                         pgstream.emit('error', quotaError);
                     }
                     if((metrics.gzipSize || metrics.size) > COPY_FROM_MAX_POST_SIZE) {
                         const maxPostSizeError = new Error(
                             `COPY FROM maximum POST size of ${COPY_FROM_MAX_POST_SIZE_PRETTY} exceeded`
                         );
-                        metrics.end(null, maxPostSizeError);
                         pgstream.emit('error', maxPostSizeError);
                     }
                 })

--- a/app/controllers/copy_controller.js
+++ b/app/controllers/copy_controller.js
@@ -135,7 +135,9 @@ function handleCopyFrom (logger) {
                         return next(quotaError);
                     }
                     if((metrics.gzipSize || metrics.size) > copy_from_max_post_size) {
-                        const maxPostSizeError = new Error(`COPY FROM maximum POST size of ${copy_from_max_post_size_pretty} exceeded`);
+                        const maxPostSizeError = new Error(
+                            `COPY FROM maximum POST size of ${copy_from_max_post_size_pretty} exceeded`
+                        );
                         metrics.end(null, maxPostSizeError);
                         req.unpipe(pgstream);
                         return next(maxPostSizeError);

--- a/app/controllers/copy_controller.js
+++ b/app/controllers/copy_controller.js
@@ -4,7 +4,6 @@ const userMiddleware = require('../middlewares/user');
 const errorMiddleware = require('../middlewares/error');
 const authorizationMiddleware = require('../middlewares/authorization');
 const connectionParamsMiddleware = require('../middlewares/connection-params');
-const timeoutLimitsMiddleware = require('../middlewares/timeout-limits');
 const { initializeProfilerMiddleware } = require('../middlewares/profiler');
 const rateLimitsMiddleware = require('../middlewares/rate-limit');
 const { RATE_LIMIT_ENDPOINTS_GROUPS } = rateLimitsMiddleware;
@@ -31,7 +30,6 @@ CopyController.prototype.route = function (app) {
             rateLimitsMiddleware(this.userLimitsService, endpointGroup),
             authorizationMiddleware(this.metadataBackend),
             connectionParamsMiddleware(this.userDatabaseService),
-            timeoutLimitsMiddleware(this.metadataBackend),
             validateCopyQuery(),
             handleCopyFrom(this.logger),
             errorHandler(),
@@ -46,7 +44,6 @@ CopyController.prototype.route = function (app) {
             rateLimitsMiddleware(this.userLimitsService, endpointGroup),
             authorizationMiddleware(this.metadataBackend),
             connectionParamsMiddleware(this.userDatabaseService),
-            timeoutLimitsMiddleware(this.metadataBackend),
             validateCopyQuery(),
             handleCopyTo(this.logger),
             errorHandler(),

--- a/app/controllers/copy_controller.js
+++ b/app/controllers/copy_controller.js
@@ -102,8 +102,8 @@ function handleCopyFrom (logger) {
         const sql = req.query.q;
         const { userDbParams, user, dbRemainingQuota } = res.locals;
         const isGzip = req.get('content-encoding') === 'gzip';
-        const copy_from_max_post_size = global.settings.copy_from_max_post_size || 1.99 * 1024 * 1024 * 1024; // 1.99 GB
-        const copy_from_max_post_size_pretty = global.settings.copy_from_max_post_size_pretty || '2 GB';
+        const COPY_FROM_MAX_POST_SIZE = global.settings.copy_from_max_post_size || 1.99 * 1024 * 1024 * 1024; // 1.99 GB
+        const COPY_FROM_MAX_POST_SIZE_PRETTY = global.settings.copy_from_max_post_size_pretty || '2 GB';
 
         const streamCopy = new StreamCopy(sql, userDbParams);
         const metrics = new StreamCopyMetrics(logger, 'copyfrom', sql, user, isGzip);
@@ -134,9 +134,9 @@ function handleCopyFrom (logger) {
                         req.unpipe(pgstream);
                         return next(quotaError);
                     }
-                    if((metrics.gzipSize || metrics.size) > copy_from_max_post_size) {
+                    if((metrics.gzipSize || metrics.size) > COPY_FROM_MAX_POST_SIZE) {
                         const maxPostSizeError = new Error(
-                            `COPY FROM maximum POST size of ${copy_from_max_post_size_pretty} exceeded`
+                            `COPY FROM maximum POST size of ${COPY_FROM_MAX_POST_SIZE_PRETTY} exceeded`
                         );
                         metrics.end(null, maxPostSizeError);
                         req.unpipe(pgstream);

--- a/app/middlewares/db-quota.js
+++ b/app/middlewares/db-quota.js
@@ -1,0 +1,21 @@
+const PSQL = require('cartodb-psql');
+
+module.exports = function dbQuota () {
+    return function dbQuotaMiddleware (req, res, next) {
+        const { userDbParams } = res.locals;
+        const pg = new PSQL(userDbParams);
+        pg.connect((err, client, done) => {
+            if (err) {
+                return next(err);
+            }
+            client.query('SELECT _CDB_UserQuotaInBytes() - CDB_UserDataSize(current_schema())', (err, res) => {
+                if(err) {
+                    return next(err);
+                }
+                console.warn(res);
+                done();
+                next();
+            });
+        });
+    };
+};

--- a/app/services/stream_copy.js
+++ b/app/services/stream_copy.js
@@ -39,7 +39,7 @@ module.exports = class StreamCopy {
                     return cb(err);
                 }
 
-                let streamMaker = action === ACTION_TO ? copyTo : copyFrom;
+                const streamMaker = action === ACTION_TO ? copyTo : copyFrom;
                 this.stream = streamMaker(this.sql);
                 const pgstream = client.query(this.stream);
 

--- a/app/services/stream_copy.js
+++ b/app/services/stream_copy.js
@@ -8,7 +8,10 @@ const ACTION_FROM = 'from';
 
 module.exports = class StreamCopy {
     constructor(sql, userDbParams) {
-        this.pg = new PSQL(userDbParams);
+        const dbParams = Object.assign({}, userDbParams, {
+            port: global.settings.db_batch_port || userDbParams.port
+        });
+        this.pg = new PSQL(dbParams);
         this.sql = sql;
         this.stream = null;
     }

--- a/app/services/stream_copy.js
+++ b/app/services/stream_copy.js
@@ -53,7 +53,7 @@ module.exports = class StreamCopy {
                             cancelingClient.cancel(client, pgstream);
 
                             // see https://node-postgres.com/api/pool#releasecallback
-                            done(err);
+                            return done(err);
                         } else if (action === ACTION_FROM) {
                             client.connection.sendCopyFail('CARTO SQL API: Connection closed by client');
                         }

--- a/app/services/stream_copy.js
+++ b/app/services/stream_copy.js
@@ -5,8 +5,10 @@ const { Client } = require('pg');
 
 const ACTION_TO = 'to';
 const ACTION_FROM = 'from';
+const DEFAULT_TIMEOUT = "'5h'";
 
 module.exports = class StreamCopy {
+
     constructor(sql, userDbParams) {
         const dbParams = Object.assign({}, userDbParams, {
             port: global.settings.db_batch_port || userDbParams.port
@@ -14,6 +16,7 @@ module.exports = class StreamCopy {
         this.pg = new PSQL(dbParams);
         this.sql = sql;
         this.stream = null;
+        this.timeout = global.settings.copy_timeout || DEFAULT_TIMEOUT;
     }
 
     static get ACTION_TO() {
@@ -29,6 +32,8 @@ module.exports = class StreamCopy {
             if (err) {
                 return cb(err);
             }
+
+            client.query('SET statement_timeout=' + this.timeout);
 
             let streamMaker = action === ACTION_TO ? copyTo : copyFrom;
             this.stream = streamMaker(this.sql);

--- a/config/environments/development.js.example
+++ b/config/environments/development.js.example
@@ -35,6 +35,7 @@ module.exports.db_batch_port      = '5432';
 module.exports.finished_jobs_ttl_in_seconds = 2 * 3600; // 2 hours
 module.exports.batch_query_timeout = 12 * 3600 * 1000; // 12 hours in milliseconds
 module.exports.batch_log_filename = 'logs/batch-queries.log';
+module.exports.copy_timeout = "'5h'";
 // Max number of queued jobs a user can have at a given time
 module.exports.batch_max_queued_jobs = 64;
 // Capacity strategy to use.

--- a/config/environments/development.js.example
+++ b/config/environments/development.js.example
@@ -36,6 +36,8 @@ module.exports.finished_jobs_ttl_in_seconds = 2 * 3600; // 2 hours
 module.exports.batch_query_timeout = 12 * 3600 * 1000; // 12 hours in milliseconds
 module.exports.batch_log_filename = 'logs/batch-queries.log';
 module.exports.copy_timeout = "'5h'";
+module.exports.copy_from_max_post_size = 1.99 * 1024 * 1024 * 1024 // 1.99 GB;
+module.exports.copy_from_max_post_size_pretty = '2 GB';
 // Max number of queued jobs a user can have at a given time
 module.exports.batch_max_queued_jobs = 64;
 // Capacity strategy to use.

--- a/config/environments/production.js.example
+++ b/config/environments/production.js.example
@@ -36,6 +36,7 @@ module.exports.db_batch_port      = '5432';
 module.exports.finished_jobs_ttl_in_seconds = 2 * 3600; // 2 hours
 module.exports.batch_query_timeout = 12 * 3600 * 1000; // 12 hours in milliseconds
 module.exports.batch_log_filename = 'logs/batch-queries.log';
+module.exports.copy_timeout = "'5h'";
 // Max number of queued jobs a user can have at a given time
 module.exports.batch_max_queued_jobs = 64;
 // Capacity strategy to use.

--- a/config/environments/production.js.example
+++ b/config/environments/production.js.example
@@ -37,6 +37,8 @@ module.exports.finished_jobs_ttl_in_seconds = 2 * 3600; // 2 hours
 module.exports.batch_query_timeout = 12 * 3600 * 1000; // 12 hours in milliseconds
 module.exports.batch_log_filename = 'logs/batch-queries.log';
 module.exports.copy_timeout = "'5h'";
+module.exports.copy_from_max_post_size = 1.99 * 1024 * 1024 * 1024 // 1.99 GB;
+module.exports.copy_from_max_post_size_pretty = '2 GB';
 // Max number of queued jobs a user can have at a given time
 module.exports.batch_max_queued_jobs = 64;
 // Capacity strategy to use.

--- a/config/environments/test.js.example
+++ b/config/environments/test.js.example
@@ -33,6 +33,7 @@ module.exports.db_batch_port      = '5432';
 module.exports.finished_jobs_ttl_in_seconds = 2 * 3600; // 2 hours
 module.exports.batch_query_timeout = 5 * 1000; // 5 seconds in milliseconds
 module.exports.batch_log_filename = 'logs/batch-queries.log';
+module.exports.copy_timeout = "'5h'";
 // Max number of queued jobs a user can have at a given time
 module.exports.batch_max_queued_jobs = 64;
 // Capacity strategy to use.

--- a/config/environments/test.js.example
+++ b/config/environments/test.js.example
@@ -34,6 +34,8 @@ module.exports.finished_jobs_ttl_in_seconds = 2 * 3600; // 2 hours
 module.exports.batch_query_timeout = 5 * 1000; // 5 seconds in milliseconds
 module.exports.batch_log_filename = 'logs/batch-queries.log';
 module.exports.copy_timeout = "'5h'";
+module.exports.copy_from_max_post_size = 1.99 * 1024 * 1024 * 1024 // 1.99 GB;
+module.exports.copy_from_max_post_size_pretty = '2 GB';
 // Max number of queued jobs a user can have at a given time
 module.exports.batch_max_queued_jobs = 64;
 // Capacity strategy to use.

--- a/doc/copy_queries.md
+++ b/doc/copy_queries.md
@@ -221,3 +221,10 @@ with open(download_filename, 'wb') as handle:
 print("Downloaded to: %s" % savefilename)
 ```
 
+## Limits
+
+There's a **5 hours timeout** limit for the `/copyfrom` and `/copyto` endpoints. The idea behind is that, in practice, COPY operations should not be limited by your regular query timeout.
+
+Aside, you cannot exceed your **database quota** in `/copyfrom` operations. Trying to do so will result in a `DB Quota exceeded` error, and the `COPY FROM` transaction will be rolled back.
+
+The maximum payload size of a `/copyfrom` that can be made in a single `POST` request is **limited to 2 GB**. Any attempt exceeding that size will result in a `COPY FROM maximum POST size of 2 GB exceeded` error, and again the whole transaction will be rolled back.

--- a/test/acceptance/copy-endpoints.js
+++ b/test/acceptance/copy-endpoints.js
@@ -423,7 +423,7 @@ describe('copy-endpoints', function() {
 
     });
 
-    describe('COPY timeouts: they can take longer than statement_timeout', function(done) {
+    describe('COPY timeouts: they can take longer than statement_timeout', function() {
         before('set a very small statement_timeout for regular queries', function(done) {
             assert.response(server, {
                 url: '/api/v1/sql?q=set statement_timeout = 1',

--- a/test/acceptance/copy-endpoints.js
+++ b/test/acceptance/copy-endpoints.js
@@ -191,6 +191,15 @@ describe('copy-endpoints', function() {
 
 
     describe('timeout', function() {
+        before('set a 10 ms timeout', function() {
+            this.previous_timeout = global.settings.copy_timeout;
+            global.settings.copy_timeout = 10;
+        });
+
+        after('restore previous timeout', function() {
+            global.settings.copy_timeout = this.previous_timeout;
+        });
+
         it('should fail with copyfrom and timeout', function(done){
             assert.response(server, {
                 url: '/api/v1/sql?q=set statement_timeout = 10',

--- a/test/acceptance/copy-endpoints.js
+++ b/test/acceptance/copy-endpoints.js
@@ -426,7 +426,7 @@ describe('copy-endpoints', function() {
     describe('COPY timeouts: they can take longer than statement_timeout', function() {
         before('set a very small statement_timeout for regular queries', function(done) {
             assert.response(server, {
-                url: '/api/v1/sql?q=set statement_timeout = 1',
+                url: '/api/v1/sql?q=set statement_timeout = 10',
                 headers: {host: 'vizzuality.cartodb.com'},
                 method: 'GET'
             }, done);

--- a/test/acceptance/copy-endpoints.js
+++ b/test/acceptance/copy-endpoints.js
@@ -460,7 +460,7 @@ describe('copy-endpoints', function() {
             });
         });
 
-        if('COPY TO can take longer than regular statement_timeout', function(done) {
+        it('COPY TO can take longer than regular statement_timeout', function(done) {
             assert.response(server, {
                 url: "/api/v1/sql/copyto?" + querystring.stringify({
                     q: 'COPY copy_endpoints_test TO STDOUT',
@@ -470,7 +470,7 @@ describe('copy-endpoints', function() {
                 method: 'GET'
             }, {}, function(err, res) {
                 assert.ifError(err);
-                assert.ok(res.body);
+                assert.ok(res.statusCode === 200);
                 done();
             });
         });

--- a/test/acceptance/copy-endpoints.js
+++ b/test/acceptance/copy-endpoints.js
@@ -483,7 +483,7 @@ describe('copy-endpoints', function() {
                               RETURNS bigint AS
                               $$
                               BEGIN
-                                RETURN 250 * 1024 * 1024 - 10;
+                                RETURN 250 * 1024 * 1024 - 1;
                               END;
                               $$ LANGUAGE 'plpgsql' VOLATILE;
                               `, err => done(err));
@@ -515,8 +515,22 @@ describe('copy-endpoints', function() {
                 headers: { 'Content-Type': 'application/json; charset=utf-8' }
             }, function(err, res) {
                 const response = JSON.parse(res.body);
-                console.log(response);
                 assert.deepEqual(response, { error: ["DB Quota exceeded"] });
+                done();
+            });
+        });
+
+        it('COPY TO is not affected by remaining DB quota', function(done) {
+            assert.response(server, {
+                url: "/api/v1/sql/copyto?" + querystring.stringify({
+                    q: 'COPY copy_endpoints_test TO STDOUT',
+                    filename: '/tmp/output.dmp'
+                }),
+                headers: {host: 'vizzuality.cartodb.com'},
+                method: 'GET'
+            }, {}, function(err, res) {
+                assert.ifError(err);
+                assert.ok(res.statusCode === 200);
                 done();
             });
         });

--- a/test/integration/stream_copy.test.js
+++ b/test/integration/stream_copy.test.js
@@ -1,0 +1,19 @@
+require('../helper');
+const assert = require('assert');
+
+const StreamCopy = require('../../app/services/stream_copy');
+
+describe('stream copy', function() {
+    it('uses batch api port', function(done) {
+        const userDbParams = {
+            dbname: 'cartodb_test_user_1_db',
+            dbuser: 'test_cartodb_user_1',
+            pass: 'test_cartodb_user_1_pass',
+            port: 'invalid_port'
+        };
+        const sql = 'COPY dummy_table FROM STDIN';
+        const streamCopy = new StreamCopy(sql, userDbParams);
+        assert.equal(streamCopy.pg.dbopts.port, global.settings.db_batch_port);
+        done();
+    });
+});

--- a/test/prepare_db.sh
+++ b/test/prepare_db.sh
@@ -75,7 +75,7 @@ if test x"$PREPARE_PGSQL" = xyes; then
   psql -c 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp";' ${TEST_DB}
   psql -c "CREATE EXTENSION IF NOT EXISTS plpythonu;" ${TEST_DB}
 
-  LOCAL_SQL_SCRIPTS='test populated_places_simple_reduced py_sleep'
+  LOCAL_SQL_SCRIPTS='test populated_places_simple_reduced py_sleep quota_mock'
   REMOTE_SQL_SCRIPTS='CDB_QueryStatements CDB_QueryTables CDB_CartodbfyTable CDB_TableMetadata CDB_ForeignTable CDB_UserTables CDB_ColumnNames CDB_ZoomFromScale CDB_OverviewsSupport CDB_Overviews'
 
   if test x"$OFFLINE" = xno; then

--- a/test/support/sql/quota_mock.sql
+++ b/test/support/sql/quota_mock.sql
@@ -1,0 +1,17 @@
+-- See https://github.com/CartoDB/cartodb-postgresql/blob/master/scripts-available/CDB_Quota.sql
+
+CREATE OR REPLACE FUNCTION _CDB_UserQuotaInBytes()
+RETURNS int8 AS
+$$
+    -- 250 MB
+    SELECT (250 * 1024 * 1024)::int8;
+$$ LANGUAGE sql IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION CDB_UserDataSize(schema_name TEXT)
+RETURNS bigint AS
+$$
+BEGIN
+    -- 100 MB
+    RETURN 100 * 1024 * 1024;
+END;
+$$ LANGUAGE 'plpgsql' VOLATILE;


### PR DESCRIPTION
This does a number of things:
- It sets the COPY FROM/TO to use the Batch API port, instead of the regular port (that is, use postgres directly instead of going through pgbouncer)
- It sets a specific configurable timeout for the COPY queries, set by default to 5h.
- It adds a middleware to check for the remaining DB quota, and it makes the COPY FROM fail in case it gets a bigger payload than the remaining quota.
- It adds a hard limit on the max size of the payload received by the COPY FROM. Actually that is a limit imposed by nginx configuration, but we want to catch and report a proper error in case we're close to the limit.

What is remaining: test in staging ~~and update the documentation (already being used) with the limits~~ (update: docs modified to reflect new limits).

Requesting a review cause I'm pretty sure you'll have suggestions for improvement and would like to know about them sooner rather than later :slightly_smiling_face: 