### PR TITLE
Add missing COPY config parameters to staging.js.example

### DIFF
--- a/config/environments/staging.js.example
+++ b/config/environments/staging.js.example
@@ -36,6 +36,9 @@ module.exports.db_batch_port      = '5432';
 module.exports.finished_jobs_ttl_in_seconds = 2 * 3600; // 2 hours
 module.exports.batch_query_timeout = 12 * 3600 * 1000; // 12 hours in milliseconds
 module.exports.batch_log_filename = 'logs/batch-queries.log';
+module.exports.copy_timeout = "'5h'";
+module.exports.copy_from_max_post_size = 1.99 * 1024 * 1024 * 1024 // 1.99 GB;
+module.exports.copy_from_max_post_size_pretty = '2 GB';
 // Max number of queued jobs a user can have at a given time
 module.exports.batch_max_queued_jobs = 64;
 // Capacity strategy to use.


### PR DESCRIPTION
I forgot to add these to the staging example file and missed them when
testing some more config changes there.

Related to https://github.com/CartoDB/CartoDB-SQL-API/pull/523

@oleurud trivial review, please (and sorry for bothering with silly mistakes, I was tempted to commit straight in master...)