### PR TITLE
Copy configs tweak

### DIFF
--- a/app/controllers/copy_controller.js
+++ b/app/controllers/copy_controller.js
@@ -102,7 +102,7 @@ function handleCopyFrom (logger) {
         const sql = req.query.q;
         const { userDbParams, user, dbRemainingQuota } = res.locals;
         const isGzip = req.get('content-encoding') === 'gzip';
-        const COPY_FROM_MAX_POST_SIZE = global.settings.copy_from_max_post_size || 1.99 * 1024 * 1024 * 1024; // 1.99 GB
+        const COPY_FROM_MAX_POST_SIZE = global.settings.copy_from_max_post_size || 2 * 1024 * 1024 * 1024; // 2 GB
         const COPY_FROM_MAX_POST_SIZE_PRETTY = global.settings.copy_from_max_post_size_pretty || '2 GB';
 
         const streamCopy = new StreamCopy(sql, userDbParams);

--- a/config/environments/development.js.example
+++ b/config/environments/development.js.example
@@ -36,7 +36,7 @@ module.exports.finished_jobs_ttl_in_seconds = 2 * 3600; // 2 hours
 module.exports.batch_query_timeout = 12 * 3600 * 1000; // 12 hours in milliseconds
 module.exports.batch_log_filename = 'logs/batch-queries.log';
 module.exports.copy_timeout = "'5h'";
-module.exports.copy_from_max_post_size = 1.99 * 1024 * 1024 * 1024 // 1.99 GB;
+module.exports.copy_from_max_post_size = 2 * 1024 * 1024 * 1024 // 2 GB;
 module.exports.copy_from_max_post_size_pretty = '2 GB';
 // Max number of queued jobs a user can have at a given time
 module.exports.batch_max_queued_jobs = 64;

--- a/config/environments/production.js.example
+++ b/config/environments/production.js.example
@@ -37,7 +37,7 @@ module.exports.finished_jobs_ttl_in_seconds = 2 * 3600; // 2 hours
 module.exports.batch_query_timeout = 12 * 3600 * 1000; // 12 hours in milliseconds
 module.exports.batch_log_filename = 'logs/batch-queries.log';
 module.exports.copy_timeout = "'5h'";
-module.exports.copy_from_max_post_size = 1.99 * 1024 * 1024 * 1024 // 1.99 GB;
+module.exports.copy_from_max_post_size = 2 * 1024 * 1024 * 1024 // 2 GB;
 module.exports.copy_from_max_post_size_pretty = '2 GB';
 // Max number of queued jobs a user can have at a given time
 module.exports.batch_max_queued_jobs = 64;

--- a/config/environments/staging.js.example
+++ b/config/environments/staging.js.example
@@ -37,7 +37,7 @@ module.exports.finished_jobs_ttl_in_seconds = 2 * 3600; // 2 hours
 module.exports.batch_query_timeout = 12 * 3600 * 1000; // 12 hours in milliseconds
 module.exports.batch_log_filename = 'logs/batch-queries.log';
 module.exports.copy_timeout = "'5h'";
-module.exports.copy_from_max_post_size = 1.99 * 1024 * 1024 * 1024 // 1.99 GB;
+module.exports.copy_from_max_post_size = 2 * 1024 * 1024 * 1024 // 2 GB;
 module.exports.copy_from_max_post_size_pretty = '2 GB';
 // Max number of queued jobs a user can have at a given time
 module.exports.batch_max_queued_jobs = 64;

--- a/config/environments/staging.js.example
+++ b/config/environments/staging.js.example
@@ -36,6 +36,9 @@ module.exports.db_batch_port      = '5432';
 module.exports.finished_jobs_ttl_in_seconds = 2 * 3600; // 2 hours
 module.exports.batch_query_timeout = 12 * 3600 * 1000; // 12 hours in milliseconds
 module.exports.batch_log_filename = 'logs/batch-queries.log';
+module.exports.copy_timeout = "'5h'";
+module.exports.copy_from_max_post_size = 1.99 * 1024 * 1024 * 1024 // 1.99 GB;
+module.exports.copy_from_max_post_size_pretty = '2 GB';
 // Max number of queued jobs a user can have at a given time
 module.exports.batch_max_queued_jobs = 64;
 // Capacity strategy to use.

--- a/config/environments/test.js.example
+++ b/config/environments/test.js.example
@@ -34,7 +34,7 @@ module.exports.finished_jobs_ttl_in_seconds = 2 * 3600; // 2 hours
 module.exports.batch_query_timeout = 5 * 1000; // 5 seconds in milliseconds
 module.exports.batch_log_filename = 'logs/batch-queries.log';
 module.exports.copy_timeout = "'5h'";
-module.exports.copy_from_max_post_size = 1.99 * 1024 * 1024 * 1024 // 1.99 GB;
+module.exports.copy_from_max_post_size = 2 * 1024 * 1024 * 1024 // 2 GB;
 module.exports.copy_from_max_post_size_pretty = '2 GB';
 // Max number of queued jobs a user can have at a given time
 module.exports.batch_max_queued_jobs = 64;


### PR DESCRIPTION
This PR does a couple of things, mostly for housekeeping:
- it adds the missing copy configs to `config/environments/staging.js.example`
- it sets the default COPY_FROM_MAX_POST_SIZE to exactly 2 GB.

It was previously set to 1.99 GB (0.5 % error, a small lie) in order to be able to report a meaningful error to the client, instead of having nginx report a different more obscure error.

Now the nginx limitation is removed for that endpoint, so it gives us the flexibility of modifying this limit at app level (chances are in a future it will be overridable by user).