### PR TITLE
Fix paused stream (DB socket) after copy to

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ Released 2018-mm-dd
 Bug fixes:
   * Errors from zlib while gunzipping (`/sql/copyfrom` compressed requests) are now handled correctly.
   * Ensure exports temporal folder
+  * Fix an issue with COPY TO returning paused DB connections to the pool #537
 
 
 ## 2.2.0

--- a/app/services/stream_copy.js
+++ b/app/services/stream_copy.js
@@ -44,7 +44,12 @@ module.exports = class StreamCopy {
                 const pgstream = client.query(this.stream);
 
                 pgstream
-                    .on('end', () => done())
+                    .on('end', () => {
+                        if(action === ACTION_TO) {
+                            pgstream.connection.stream.resume();
+                        }
+                        done();
+                    })
                     .on('error', err => done(err))
                     .on('cancelQuery', err => {
                         if(action === ACTION_TO) {

--- a/test/acceptance/copy-endpoints.js
+++ b/test/acceptance/copy-endpoints.js
@@ -314,7 +314,7 @@ describe('copy-endpoints', function() {
                 return new Promise(resolve => {
                     assert.response(server, {
                         url: "/api/v1/sql/copyto?" + querystring.stringify({
-                            q: 'COPY copy_endpoints_test TO STDOUT',
+                            q: `COPY (SELECT * FROM generate_series(1, 10000)) TO STDOUT`,
                             filename: '/tmp/output.dmp'
                         }),
                         headers: {host: 'vizzuality.cartodb.com'},


### PR DESCRIPTION
This PR does 2 things:
- It tweaks an existing test to make the issue reproducible (see the failures in the first commit)
- It fixes the underlying problem with a workaround.