### PR TITLE
cancel query when quota exceeded or max POST size

### DIFF
--- a/app/controllers/copy_controller.js
+++ b/app/controllers/copy_controller.js
@@ -140,12 +140,14 @@ function handleCopyFrom (logger) {
 
                     if(metrics.size > dbRemainingQuota) {
                         const quotaError = new Error('DB Quota exceeded');
+                        pgstream.emit('cancelQuery', err);
                         pgstream.emit('error', quotaError);
                     }
                     if((metrics.gzipSize || metrics.size) > COPY_FROM_MAX_POST_SIZE) {
                         const maxPostSizeError = new Error(
                             `COPY FROM maximum POST size of ${COPY_FROM_MAX_POST_SIZE_PRETTY} exceeded`
                         );
+                        pgstream.emit('cancelQuery', err);
                         pgstream.emit('error', maxPostSizeError);
                     }
                 })


### PR DESCRIPTION
Fix: https://github.com/CartoDB/oncall/issues/436 & https://github.com/CartoDB/cartodb-platform/issues/5094

When we detect the user is exceeding its limit or a POST is bigger than 2Gb, we are returning the error, but we don't cancel the query. This is why the number process are increasing.
