### PR TITLE
 Properly mock Date.now() for tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1649,6 +1649,12 @@
         }
       }
     },
+    "mockdate": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mockdate/-/mockdate-2.0.2.tgz",
+      "integrity": "sha1-WuDA6vj+I+AJzQH5iJtCxPY0rxI=",
+      "dev": true
+    },
     "moment": {
       "version": "2.22.2",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "jshint": "~2.6.0",
     "libxmljs": "0.19.5",
     "mocha": "3.2.0",
+    "mockdate": "^2.0.2",
     "shapefile": "0.3.0",
     "sqlite3": "4.0.0",
     "zipfile": "0.5.11"

--- a/test/acceptance/last-modified-header.js
+++ b/test/acceptance/last-modified-header.js
@@ -5,6 +5,7 @@ require('../helper');
 var server = require('../../app/server')();
 var assert = require('../support/assert');
 var qs = require('querystring');
+var MockDate = require('mockdate');
 
 describe('last modified header', function() {
 
@@ -64,10 +65,7 @@ describe('last modified header', function() {
             api_key: 1234
         });
         var fixedDateNow = Date.now();
-        var dateNowFn = Date.now;
-        Date.now = function() {
-            return fixedDateNow;
-        };
+	MockDate.set(fixedDateNow);
         assert.response(server,
             {
                 url: '/api/v1/sql?' + query,
@@ -80,7 +78,7 @@ describe('last modified header', function() {
                 statusCode: 200
             },
             function(err, res) {
-                Date.now = dateNowFn;
+                MockDate.reset();
                 assert.equal(res.headers['last-modified'], new Date(fixedDateNow).toUTCString());
                 done();
             }
@@ -93,10 +91,7 @@ describe('last modified header', function() {
             api_key: 1234
         });
         var fixedDateNow = Date.now();
-        var dateNowFn = Date.now;
-        Date.now = function() {
-            return fixedDateNow;
-        };
+	MockDate.set(fixedDateNow);
         assert.response(server,
             {
                 url: '/api/v1/sql?' + query,
@@ -109,7 +104,7 @@ describe('last modified header', function() {
                 statusCode: 200
             },
             function(err, res) {
-                Date.now = dateNowFn;
+                MockDate.reset();
                 assert.equal(res.headers['last-modified'], new Date(fixedDateNow).toUTCString());
                 done();
             }


### PR DESCRIPTION
Under node 10, some tests fail _sometimes_ because of the way `Date.now()` is mocked: https://github.com/CartoDB/CartoDB-SQL-API/blob/b9f647f15d3c23c8859fe1ad3d38e50193d965ab/test/acceptance/last-modified-header.js#L66-L70 (though they work fine under node 6).

This can be checked on current master by running this:

```
$ for i in $(seq 1 100); do echo $i; test/run_tests.sh --nocreate  test/acceptance/last-modified-header.js || break; done
...
  5 passing (181ms)
  1 failing

  1) last modified header should use Date.now() for functions or results with no table associated:

      Uncaught AssertionError [ERR_ASSERTION]: 'Tue, 11 Dec 2018 10:58:05 GMT' == 'Tue, 11 Dec 2018 10:58:04 GMT'
      + expected - actual

      -Tue, 11 Dec 2018 10:58:05 GMT
      +Tue, 11 Dec 2018 10:58:04 GMT
      
      at test/acceptance/last-modified-header.js:113:24
      at Server.<anonymous> (test/support/assert.js:108:24)
      at emitCloseNT (net.js:1618:8)
      at process._tickCallback (internal/process/next_tick.js:63:19)
```

(just by chance some request may lay on the second after `fixedDateNow` is fixed).

This fixes the issue by using [MockDate](https://github.com/boblauer/MockDate), instead of elaborating our own mock (quite simple and understandable code anyway), making the tests more robust.

I'm using node v10.14.1