### PR TITLE
Fix version of cartodb-psql (remove caret ^)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "basic-auth": "^2.0.0",
     "bintrees": "1.0.1",
     "bunyan": "1.8.1",
-    "cartodb-psql": "^0.13.1",
+    "cartodb-psql": "0.13.1",
     "cartodb-query-tables": "0.4.0",
     "cartodb-redis": "2.1.0",
     "debug": "2.2.0",


### PR DESCRIPTION
One liner. In the original change I think I added the caret just because `npm install cartodb-psql@0.13.1` did so, but the semantics of the caret are can be tricky. This change is to be on the safe (no deploy required IMHO).