### PR TITLE
remove python from libraries support section in Dev Center

### DIFF
--- a/docs/support/04-libraries-support.md
+++ b/docs/support/04-libraries-support.md
@@ -13,9 +13,6 @@ To make things easier for developers, we provide client libraries for different 
 - **PHP**  
   The PHP library provides a wrapper around the SQL API to get PHP objects straight from SQL calls to CARTO. [Fork it on GitHub!](https://github.com/Vizzuality/cartodbclient-php)
 
-- **PYTHON**  
-  Provides API Key access to SQL API. [Fork it on GitHub!](https://github.com/CartoDB/carto-python)
-
 - **JAVA**  
   Very basic example of how to access CARTO SQL API. [Fork it on GitHub!](https://github.com/cartodb/cartodb-java-client)
 


### PR DESCRIPTION
Python SDK is already a separated library and maintained by CARTO
