### PR TITLE
Log pg copy to warnings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ Announcements:
 * Improve batch-queries draining while exiting the process #582
 * Implement a mechanism to short out hung connections in copy-from endpoints.
 * Implement POST method for copy-to endpoint.
+* Log NOTICE's and WARNING's coming from COPY TO queries.
 * Retrieve the exact PG field type information in JSON format responses.
 
 

--- a/app/services/stream_copy.js
+++ b/app/services/stream_copy.js
@@ -53,6 +53,7 @@ module.exports = class StreamCopy {
                 if (action === ACTION_TO) {
                     pgstream.on('end', () => done());
                     pgstream.on('error', () => this._cancel(client.processID, action));
+                    pgstream.on('warning', (msg) => this.logger.warn(msg));
                 } else if (action === ACTION_FROM) {
                     pgstream.on('finish', () => done());
                     pgstream.on('error', err =>  client.connection.sendCopyFail(err.message));

--- a/package-lock.json
+++ b/package-lock.json
@@ -2397,7 +2397,7 @@
       "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
     },
     "pg-copy-streams": {
-      "version": "github:cartodb/node-pg-copy-streams#be101502d9a7ee116ae3a0b3c94487869f0cada9",
+      "version": "github:cartodb/node-pg-copy-streams#c9157cd1ab40e02455d949439ae8a913c9ee524e",
       "from": "github:cartodb/node-pg-copy-streams#v2.x-carto"
     },
     "pg-int8": {


### PR DESCRIPTION
Related to https://github.com/CartoDB/node-pg-copy-streams/pull/9

Tested with the same test function that raises a warning, got the following result now:
```
$ QUERY="COPY+(SELECT+*+FROM+test_return_one())+to+STDOUT+WITH+(FORMAT+'csv',+HEADER+true)"
$ curl --output - "${BASE_URL}/api/v1/sql/copyto?api_key=${API_KEY}&q=${QUERY}"
test_return_one
1
```

and in the copy logs:
```
{"name":"data-ingestion","hostname":"carto-rtorre","pid":31254,"level":40,"msg":"Got an interspersed message: SWARNING\u0000VWARNING\u0000C01000\u0000Mhey, this is returning one\u0000WPL/pgSQL function test_return_one() line 3 at RAISE\u0000Fpl_exec.c\u0000L3337\u0000Rexec_stmt_raise\u0000\u0000","time":"2019-06-04T17:12:32+0200","v":0}
{"name":"data-ingestion","hostname":"carto-rtorre","pid":31254,"level":30,"type":"copyto","format":"TEXT","size":18,"rows":2,"gzip":false,"cdb-user":"development","time":0.002,"timestamp":"2019-06-04T15:12:32.315Z","sql":"COPY (SELECT * FROM test_return_one()) to STDOUT WITH (FORMAT 'csv', HEADER true)","success":true,"msg":"","v":0}
```