### PR TITLE
 Remove old abort checker

### DIFF
--- a/app/middlewares/cancel-on-client-abort.js
+++ b/app/middlewares/cancel-on-client-abort.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = function cancelOnClientAbort () {
+    return function cancelOnClientAbortMiddleware (req, res, next) {
+        req.on('aborted', () => {
+            if (req.formatter && typeof req.formatter.cancel === 'function') {
+                req.formatter.cancel();
+            }
+        });
+
+        next();
+    };
+};

--- a/app/models/formats/pg.js
+++ b/app/models/formats/pg.js
@@ -75,9 +75,6 @@ PostgresFormat.prototype.handleQueryEnd = function(result) {
 
   step (
     function packageResult() {
-      if ( that.opts.abortChecker ) {
-        that.opts.abortChecker('packageResult');
-      }
       that.transform(result, that.opts, this);
     },
     function sendResults(err, out){


### PR DESCRIPTION
Regarding this piece of code:

```js
// client-abort.js
'use strict';

const http = require('http')
const port = 5555

const server = http.createServer((req, res) => {
  req.on('aborted', () => console.log(`Server: req aborted by client (req.aborted: ${req.aborted})`))
  setTimeout(() => res.end('chunk of data'), 100)
});

server.listen(port);

server.on('listening', () => {
  const req = http.get({ port });

  req.on('error', err => {
    console.error('Client: error', err)
    server.close()
  })

  setTimeout(() => req.abort(), 50)
})
```

```sh
$ node client-abort.js
Server: req aborted by client (req.aborted: true)
Client: error { Error: socket hang up
    at createHangUpError (_http_client.js:323:15)
    at Socket.socketCloseListener (_http_client.js:364:25)
    at Socket.emit (events.js:203:15)
    at TCP._handle.close (net.js:606:12) code: 'ECONNRESET' }
```


Instead, use a Node-ish mechanism to achieve the same goal

