### PR TITLE
Set a hard limit on the size of the X-SQLAPI-Log header

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@ Announcements:
 * Retrieve the exact PG field type information in JSON format responses.
 * Middlewarify client abort query checker.
 * Middlewarify query controller.
+* Set a hard limit on the size of the X-SQLAPI-Log header.
 
 ## 3.0.0
 Released 2019-02-22

--- a/app/middlewares/log.js
+++ b/app/middlewares/log.js
@@ -3,6 +3,12 @@
 const { stringifyForLogs } = require('../utils/logs');
 
 const MAX_SQL_LENGTH = (global.settings.logQueries && global.settings.maxQueriesLogLength) || 1024;
+
+// This is used to set a hard limit in the header size
+// While Node accepts headers of up to 8192 character, but different libraries impose other limits
+// This might break the JSON structure of the log
+const HEADER_HARD_LIMIT = 4096;
+
 const TYPES = {
     QUERY: 'query',
     JOB: 'job'
@@ -16,7 +22,7 @@ module.exports = function log(sqlType = TYPES.QUERY) {
             }
         };
 
-        res.set('X-SQLAPI-Log', stringifyForLogs(logObj));
+        res.set('X-SQLAPI-Log', stringifyForLogs(logObj).substring(0, HEADER_HARD_LIMIT));
 
         return next();
     };
@@ -38,9 +44,10 @@ function prepareSQL(sql, sqlType) {
     }
 
     if (Array.isArray(sql)) {
+        const lengthPerQuery = MAX_SQL_LENGTH / sql.length;
         return {
             type: sqlType,
-            sql: sql.map(q => ensureMaxQueryLength(q))
+            sql: sql.map(q => ensureMaxQueryLength(q, lengthPerQuery))
         };
     }
 
@@ -88,6 +95,6 @@ function prepareBatchFallbackQuery(sql) {
     return fallbackQuery;
 }
 
-function ensureMaxQueryLength(sql) {
-    return sql.substring(0, MAX_SQL_LENGTH);
+function ensureMaxQueryLength(sql, length = MAX_SQL_LENGTH) {
+    return sql.substring(0, length);
 }

--- a/app/middlewares/log.js
+++ b/app/middlewares/log.js
@@ -4,9 +4,9 @@ const { stringifyForLogs } = require('../utils/logs');
 
 const MAX_SQL_LENGTH = (global.settings.logQueries && global.settings.maxQueriesLogLength) || 1024;
 
-// This is used to set a hard limit in the header size
-// While Node accepts headers of up to 8192 character, but different libraries impose other limits
-// This might break the JSON structure of the log
+// This is used to set a hard limit to the header size
+// While Node accepts headers of up to 8192 character, different libraries impose other limits
+// This might break the JSON structure of the log, but avoids responses being dropped by varnish
 const HEADER_HARD_LIMIT = 4096;
 
 const TYPES = {

--- a/test/support/assert.js
+++ b/test/support/assert.js
@@ -77,6 +77,7 @@ assert.response = function(server, req, res, callback) {
                             '     Got: [red]{' + response.body + '}')
                     );
                 }
+                
 
                 // Assert response status
                 if (typeof status === 'number') {


### PR DESCRIPTION
Prevents X-SQLAPI-Log having a high length when dealing with multiple queries:
- If there are N queries, each one will include at most `global.settings.maxQueriesLogLength / N` when printed.
- As N can be arbitrarily high and the header contains more characters than just the query, it sets a hard limit of 4096 characters for the header. 