### PR TITLE
Add Rate limit headers to CORS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@ Announcements:
 * Middlewarify query controller.
 * Set a hard limit on the size of the X-SQLAPI-Log header.
 * Update cartodb-psql to 0.14.0 and use the timeout parameter for pg.query.
+* Expose rate limit headers for CORS requests.
 
 ## 3.0.0
 Released 2019-02-22

--- a/app/middlewares/cors.js
+++ b/app/middlewares/cors.js
@@ -19,7 +19,7 @@ module.exports = function cors(extraHeaders = []) {
 
         res.header('Access-Control-Allow-Origin', '*');
         res.header('Access-Control-Allow-Headers', headers.join(', '));
-        res.header('Access-Control-Expose-Headers', exposedHeaders.join(', '))
+        res.header('Access-Control-Expose-Headers', exposedHeaders.join(', '));
 
         next();
     };

--- a/app/middlewares/cors.js
+++ b/app/middlewares/cors.js
@@ -7,15 +7,19 @@ module.exports = function cors(extraHeaders = []) {
             'X-Prototype-Version',
             'X-CSRF-Token',
             'Authorization',
+            ...extraHeaders
+        ];
+
+        const exposedHeaders = [
             'Carto-Rate-Limit-Limit',
             'Carto-Rate-Limit-Remaining',
             'Carto-Rate-Limit-Reset',
-            'Retry-After',
-            ...extraHeaders
+            'Retry-After'
         ];
 
         res.header('Access-Control-Allow-Origin', '*');
         res.header('Access-Control-Allow-Headers', headers.join(', '));
+        res.header('Access-Control-Expose-Headers', exposedHeaders.join(', '))
 
         next();
     };

--- a/app/middlewares/cors.js
+++ b/app/middlewares/cors.js
@@ -1,15 +1,21 @@
 'use strict';
 
-module.exports = function cors(extraHeaders) {
-    return function(req, res, next) {
-        var baseHeaders = 'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Authorization';
-
-        if(extraHeaders) {
-            baseHeaders += ', ' + extraHeaders;
-        }
+module.exports = function cors(extraHeaders = []) {
+    return function (req, res, next) {
+        const headers = [
+            'X-Requested-With',
+            'X-Prototype-Version',
+            'X-CSRF-Token',
+            'Authorization',
+            'Carto-Rate-Limit-Limit',
+            'Carto-Rate-Limit-Remaining',
+            'Carto-Rate-Limit-Reset',
+            'Retry-After',
+            ...extraHeaders
+        ];
 
         res.header('Access-Control-Allow-Origin', '*');
-        res.header('Access-Control-Allow-Headers', baseHeaders);
+        res.header('Access-Control-Allow-Headers', headers.join(', '));
 
         next();
     };

--- a/test/acceptance/app-configuration.js
+++ b/test/acceptance/app-configuration.js
@@ -5,6 +5,16 @@ require('../helper');
 var server = require('../../app/server')();
 var assert = require('../support/assert');
 
+const accessControlHeaders = [
+    'X-Requested-With',
+    'X-Prototype-Version',
+    'X-CSRF-Token',
+    'Authorization',
+    'Carto-Rate-Limit-Limit',
+    'Carto-Rate-Limit-Remaining',
+    'Carto-Rate-Limit-Reset',
+    'Retry-After'
+].join(', ');
 
 describe('app-configuration', function() {
 
@@ -61,7 +71,7 @@ describe('app-configuration', function() {
         }, RESPONSE_OK, function(err, res) {
             assert.equal(
                 res.headers['access-control-allow-headers'],
-                'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Authorization, Carto-Rate-Limit-Limit, Carto-Rate-Limit-Remaining, Carto-Rate-Limit-Reset, Retry-After'
+                accessControlHeaders
             );
             assert.equal(res.headers['access-control-allow-origin'], '*');
             done();
@@ -78,7 +88,7 @@ describe('app-configuration', function() {
             assert.equal(res.body, '');
             assert.equal(
                 res.headers['access-control-allow-headers'],
-                'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Authorization, Carto-Rate-Limit-Limit, Carto-Rate-Limit-Remaining, Carto-Rate-Limit-Reset, Retry-After'
+                accessControlHeaders
             );
             assert.equal(res.headers['access-control-allow-origin'], '*');
             done();
@@ -160,7 +170,7 @@ describe('app-configuration', function() {
             assert.equal(res.headers['access-control-allow-origin'], '*');
             assert.equal(
                 res.headers['access-control-allow-headers'],
-                'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Authorization, Carto-Rate-Limit-Limit, Carto-Rate-Limit-Remaining, Carto-Rate-Limit-Reset, Retry-After'
+                accessControlHeaders
             );
             done();
         });

--- a/test/acceptance/app-configuration.js
+++ b/test/acceptance/app-configuration.js
@@ -61,7 +61,7 @@ describe('app-configuration', function() {
         }, RESPONSE_OK, function(err, res) {
             assert.equal(
                 res.headers['access-control-allow-headers'],
-                'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Authorization'
+                'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Authorization, Carto-Rate-Limit-Limit, Carto-Rate-Limit-Remaining, Carto-Rate-Limit-Reset, Retry-After'
             );
             assert.equal(res.headers['access-control-allow-origin'], '*');
             done();
@@ -78,7 +78,7 @@ describe('app-configuration', function() {
             assert.equal(res.body, '');
             assert.equal(
                 res.headers['access-control-allow-headers'],
-                'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Authorization'
+                'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Authorization, Carto-Rate-Limit-Limit, Carto-Rate-Limit-Remaining, Carto-Rate-Limit-Reset, Retry-After'
             );
             assert.equal(res.headers['access-control-allow-origin'], '*');
             done();
@@ -160,7 +160,7 @@ describe('app-configuration', function() {
             assert.equal(res.headers['access-control-allow-origin'], '*');
             assert.equal(
                 res.headers['access-control-allow-headers'],
-                "X-Requested-With, X-Prototype-Version, X-CSRF-Token, Authorization"
+                'X-Requested-With, X-Prototype-Version, X-CSRF-Token, Authorization, Carto-Rate-Limit-Limit, Carto-Rate-Limit-Remaining, Carto-Rate-Limit-Reset, Retry-After'
             );
             done();
         });

--- a/test/acceptance/app-configuration.js
+++ b/test/acceptance/app-configuration.js
@@ -16,8 +16,7 @@ const exposedHeaders = [
     'Carto-Rate-Limit-Limit',
     'Carto-Rate-Limit-Remaining',
     'Carto-Rate-Limit-Reset',
-    'Retry-After',
-    'X-Cache'
+    'Retry-After'
 ].join(', ');
 
 describe('app-configuration', function() {

--- a/test/acceptance/app-configuration.js
+++ b/test/acceptance/app-configuration.js
@@ -9,11 +9,15 @@ const accessControlHeaders = [
     'X-Requested-With',
     'X-Prototype-Version',
     'X-CSRF-Token',
-    'Authorization',
+    'Authorization'
+].join(', ');
+
+const exposedHeaders = [
     'Carto-Rate-Limit-Limit',
     'Carto-Rate-Limit-Remaining',
     'Carto-Rate-Limit-Reset',
-    'Retry-After'
+    'Retry-After',
+    'X-Cache'
 ].join(', ');
 
 describe('app-configuration', function() {
@@ -73,6 +77,10 @@ describe('app-configuration', function() {
                 res.headers['access-control-allow-headers'],
                 accessControlHeaders
             );
+            assert.equal(
+                res.headers['access-control-expose-headers'],
+                exposedHeaders
+            );
             assert.equal(res.headers['access-control-allow-origin'], '*');
             done();
         });
@@ -89,6 +97,10 @@ describe('app-configuration', function() {
             assert.equal(
                 res.headers['access-control-allow-headers'],
                 accessControlHeaders
+            );
+            assert.equal(
+                res.headers['access-control-expose-headers'],
+                exposedHeaders
             );
             assert.equal(res.headers['access-control-allow-origin'], '*');
             done();
@@ -171,6 +183,10 @@ describe('app-configuration', function() {
             assert.equal(
                 res.headers['access-control-allow-headers'],
                 accessControlHeaders
+            );
+            assert.equal(
+                res.headers['access-control-expose-headers'],
+                exposedHeaders
             );
             done();
         });


### PR DESCRIPTION
Fix #617 

It seems like nobody else is calling cors() so I took the liberty to change the function signature to accept an array instead of a string, for readability.