### PR TITLE
Default to stdout logging

### DIFF
--- a/config/environments/development.js.example
+++ b/config/environments/development.js.example
@@ -38,7 +38,7 @@ module.exports.useProfiler = true;
 module.exports.log_format   = '[:date] :remote-addr :method :req[Host]:url :status :response-time ms -> :res[Content-Type] (:res[X-SQLAPI-Profiler]) (:res[X-SQLAPI-Errors]) (:res[X-SQLAPI-Log])';
 // If log_filename is given logs will be written there, in append mode. Otherwise stdout is used (default).
 // Log file will be re-opened on receiving the HUP signal
-module.exports.log_filename = 'logs/cartodb-sql-api.log';
+module.exports.log_filename = undefined;
 // Regular expression pattern to extract username
 // from hostname. Must have a single grabbing block.
 module.exports.user_from_host = '^(.*)\\.localhost';
@@ -61,7 +61,7 @@ module.exports.db_port      = '5432';
 module.exports.db_batch_port      = '5432';
 module.exports.finished_jobs_ttl_in_seconds = 2 * 3600; // 2 hours
 module.exports.batch_query_timeout = 12 * 3600 * 1000; // 12 hours in milliseconds
-module.exports.batch_log_filename = 'logs/batch-queries.log';
+module.exports.batch_log_filename = undefined;
 module.exports.copy_timeout = "'5h'";
 module.exports.copy_from_max_post_size = 2 * 1024 * 1024 * 1024 // 2 GB;
 module.exports.copy_from_max_post_size_pretty = '2 GB';

--- a/config/environments/development.js.example
+++ b/config/environments/development.js.example
@@ -148,7 +148,7 @@ module.exports.ratelimits = {
 }
 
 module.exports.validatePGEntitiesAccess = false;
-module.exports.dataIngestionLogPath = 'logs/data-ingestion.log';
+module.exports.dataIngestionLogPath = undefined;
 module.exports.logQueries = true;
 module.exports.maxQueriesLogLength = 2000;
 


### PR DESCRIPTION
On development environments, default to stdout logging, as we can't assume a `/logs` directory will exist.
Context https://github.com/CartoDB/support/issues/2207#issuecomment-543125871