### PR TITLE
Fix COPY Throttling bug

### DIFF
--- a/lib/services/throttler-stream.js
+++ b/lib/services/throttler-stream.js
@@ -8,34 +8,19 @@ module.exports = class Throttler extends Transform {
 
         this.pgstream = pgstream;
 
-        this.sampleLength = global.settings.copy_from_maximum_slow_input_speed_interval || 15;
-        this.minimunBytesPerSecondThershold = global.settings.copy_from_minimum_input_speed || 0;
+        this.sampleSeconds = global.settings.copy_from_maximum_slow_input_speed_interval || 15;
+        this.minimunBytesPerSampleThreshold = global.settings.copy_from_minimum_input_speed || 0;
         this.byteCount = 0;
-        this.bytesPerSecondHistory = [];
 
-        this._interval = setInterval(this._updateMetrics.bind(this), 1000);
+        this._interval = setInterval(this._updateMetrics.bind(this), this.sampleSeconds*1000);
     }
 
     _updateMetrics () {
-        this.bytesPerSecondHistory.push(this.byteCount);
-        this.byteCount = 0;
-
-        if (this.bytesPerSecondHistory.length > this.sampleLength) {
-            this.bytesPerSecondHistory.shift();
-        }
-
-        let doesNotReachThresholdCount = 0;
-
-        for (const bytesPerSecond of this.bytesPerSecondHistory) {
-            if (bytesPerSecond <= this.minimunBytesPerSecondThershold) {
-                doesNotReachThresholdCount += 1;
-            }
-        }
-
-        if (doesNotReachThresholdCount >= this.sampleLength) {
+        if (this.byteCount < this.minimunBytesPerSampleThreshold) {
             clearInterval(this._interval);
             this.pgstream.emit('error', new Error('Connection closed by server: input data too slow'));
         }
+        this.byteCount = 0;
     }
 
     _transform (chunk, encoding, callback) {

--- a/lib/services/throttler-stream.js
+++ b/lib/services/throttler-stream.js
@@ -24,15 +24,15 @@ module.exports = class Throttler extends Transform {
             this.bytesPerSecondHistory.shift();
         }
 
-        const doesNotReachThreshold = [];
+        let doesNotReachThreshold = 0;
 
         for (const bytesPerSecond of this.bytesPerSecondHistory) {
             if (bytesPerSecond <= this.minimunBytesPerSecondThershold) {
-                doesNotReachThreshold.push(true);
+                doesNotReachThreshold += 1;
             }
         }
 
-        if (doesNotReachThreshold.length >= this.sampleLength) {
+        if (doesNotReachThreshold >= this.sampleLength) {
             clearInterval(this._interval);
             this.pgstream.emit('error', new Error('Connection closed by server: input data too slow'));
         }

--- a/lib/services/throttler-stream.js
+++ b/lib/services/throttler-stream.js
@@ -24,15 +24,15 @@ module.exports = class Throttler extends Transform {
             this.bytesPerSecondHistory.shift();
         }
 
-        let doesNotReachThreshold = 0;
+        let doesNotReachThresholdCount = 0;
 
         for (const bytesPerSecond of this.bytesPerSecondHistory) {
             if (bytesPerSecond <= this.minimunBytesPerSecondThershold) {
-                doesNotReachThreshold += 1;
+                doesNotReachThresholdCount += 1;
             }
         }
 
-        if (doesNotReachThreshold >= this.sampleLength) {
+        if (doesNotReachThresholdCount >= this.sampleLength) {
             clearInterval(this._interval);
             this.pgstream.emit('error', new Error('Connection closed by server: input data too slow'));
         }

--- a/lib/services/throttler-stream.js
+++ b/lib/services/throttler-stream.js
@@ -20,7 +20,7 @@ module.exports = class Throttler extends Transform {
         this.bytesPerSecondHistory.push(this.byteCount);
         this.byteCount = 0;
 
-        if (this.bytesPerSecondHistory > this.sampleLength) {
+        if (this.bytesPerSecondHistory.length > this.sampleLength) {
             this.bytesPerSecondHistory.shift();
         }
 


### PR DESCRIPTION
This fixes one of the observed COPY problems: the unexpected "Connection closed by server: input data too slow" errors.

Instead of checking that in the latest N seconds the minimum read bytes was less than M in each one them we were checking that in any different N seconds had less than M bytes.

I've been unable to write a test to demonstrate this case so far.