### PR TITLE
Allow metrics custom headers in cors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 ## 5.0.2
 Released 2020-mm-dd
 
+- Updated allowed list of custom headers with the ones for metrics
+
 
 ## 5.0.1
 Released 2020-01-27

--- a/lib/api/middlewares/cors.js
+++ b/lib/api/middlewares/cors.js
@@ -7,6 +7,9 @@ module.exports = function cors (extraHeaders = []) {
             'X-Prototype-Version',
             'X-CSRF-Token',
             'Authorization',
+            'Carto-Source-Lib',
+            'Carto-Source-Context',
+            'Carto-Source-Context-Id',
             ...extraHeaders
         ];
 

--- a/test/acceptance/app-configuration-test.js
+++ b/test/acceptance/app-configuration-test.js
@@ -9,7 +9,10 @@ const accessControlHeaders = [
     'X-Requested-With',
     'X-Prototype-Version',
     'X-CSRF-Token',
-    'Authorization'
+    'Authorization',
+    'Carto-Source-Lib',
+    'Carto-Source-Context',
+    'Carto-Source-Context-Id'
 ].join(', ');
 
 const exposedHeaders = [


### PR DESCRIPTION
As requested in https://app.clubhouse.io/cartoteam/story/58905/implement-client-metrics-in-kepler-sql#activity-58912 we must add the new custom headers for metrics to the allowed headers list for cors.