### PR TITLE
Rename accepted headers for metrics events

### DIFF
--- a/lib/api/middlewares/cors.js
+++ b/lib/api/middlewares/cors.js
@@ -8,7 +8,7 @@ module.exports = function cors (extraHeaders = []) {
             'X-CSRF-Token',
             'Authorization',
             'Carto-Event',
-            'Carto-Event-Origin',
+            'Carto-Event-Source',
             'Carto-Event-Group-Id',
             ...extraHeaders
         ];

--- a/lib/api/middlewares/cors.js
+++ b/lib/api/middlewares/cors.js
@@ -7,9 +7,9 @@ module.exports = function cors (extraHeaders = []) {
             'X-Prototype-Version',
             'X-CSRF-Token',
             'Authorization',
-            'Carto-Source-Lib',
-            'Carto-Source-Context',
-            'Carto-Source-Context-Id',
+            'Carto-Event',
+            'Carto-Event-Origin',
+            'Carto-Event-Group-Id',
             ...extraHeaders
         ];
 

--- a/test/acceptance/app-configuration-test.js
+++ b/test/acceptance/app-configuration-test.js
@@ -10,9 +10,9 @@ const accessControlHeaders = [
     'X-Prototype-Version',
     'X-CSRF-Token',
     'Authorization',
-    'Carto-Source-Lib',
-    'Carto-Source-Context',
-    'Carto-Source-Context-Id'
+    'Carto-Event',
+    'Carto-Event-Origin',
+    'Carto-Event-Group-Id'
 ].join(', ');
 
 const exposedHeaders = [

--- a/test/acceptance/app-configuration-test.js
+++ b/test/acceptance/app-configuration-test.js
@@ -11,7 +11,7 @@ const accessControlHeaders = [
     'X-CSRF-Token',
     'Authorization',
     'Carto-Event',
-    'Carto-Event-Origin',
+    'Carto-Event-Source',
     'Carto-Event-Group-Id'
 ].join(', ');
 


### PR DESCRIPTION
After reviewing current events we agreed to rename the headers so they are closer to their corresponding event attributes.

\cc @VictorVelarde 