### PR TITLE
Do not yield to the next middleware before handleQuery is done

### DIFF
--- a/lib/api/sql/query-controller.js
+++ b/lib/api/sql/query-controller.js
@@ -106,10 +106,6 @@ function handleQuery ({ stats } = {}) {
             formatter.sendResponse(opts, (err) => {
                 formatter = null;
 
-                if (err) {
-                    next(err);
-                }
-
                 if (req.profiler) {
                     req.profiler.sendStats();
                 }
@@ -120,6 +116,12 @@ function handleQuery ({ stats } = {}) {
                     } else {
                         stats.increment('sqlapi.query.success');
                     }
+                }
+
+                if (err) {
+                    next(err);
+                } else {
+                    next();
                 }
             });
         } catch (err) {

--- a/lib/models/formats/ogr.js
+++ b/lib/models/formats/ogr.js
@@ -322,18 +322,30 @@ ExportRequest.prototype.sendFile = function (err, filename, callback) {
                 if (that.beforeSink) {
                     that.beforeSink();
                 }
-                that.istream.pipe(that.ostream);
-                callback();
+                that.istream
+                    .pipe(that.ostream)
+                    .on('end', () => {
+                        callback();
+                        that.cb();
+                    })
+                    .on('error', (err) => {
+                        callback();
+                        that.cb(err);
+                    });
             })
             .on('error', function (e) {
                 console.log("Can't send response: " + e);
                 that.ostream.end();
+                that.cb(e);
+                callback();
+            })
+            .on('end', () => {
+                that.cb();
                 callback();
             });
     } else {
         callback();
     }
-    this.cb();
 };
 
 module.exports = OgrFormat;

--- a/lib/models/formats/pg/topojson.js
+++ b/lib/models/formats/pg/topojson.js
@@ -27,6 +27,8 @@ TopoJsonFormat.prototype.handleQueryRow = function (row) {
 };
 
 TopoJsonFormat.prototype.handleQueryEnd = function () {
+    const that = this;
+
     if (this.error) {
         this.callback(this.error);
         return;
@@ -118,6 +120,7 @@ TopoJsonFormat.prototype.handleQueryEnd = function () {
                     }
                     stream.write(buffer);
                     stream.end();
+                    that.callback();
                     topology = null;
                 }
             }
@@ -125,8 +128,6 @@ TopoJsonFormat.prototype.handleQueryEnd = function () {
         });
     }
     sendResponse();
-
-    this.callback();
 };
 
 TopoJsonFormat.prototype.cancel = function () {


### PR DESCRIPTION
This PR allows appending middlewares after `handleQuery` middleware in `QueryController`.  Before that, it was yielding before streaming the results of the query into the `Response` and could end up writing in a `Response` which `Express` has actually closed.