### PR TITLE
Return 'Retry-after' header when 'Carto-Rate-Limit-Remaining' is 0.

### DIFF
--- a/lib/api/middlewares/rate-limit.js
+++ b/lib/api/middlewares/rate-limit.js
@@ -31,8 +31,8 @@ function rateLimit (userLimits, endpointGroup = null) {
                 'Carto-Rate-Limit-Remaining': remaining,
                 'Carto-Rate-Limit-Reset': reset
             });
-            
-            if (remaining == 0 && !isBlocked) {
+
+            if (remaining === 0 && !isBlocked) {
                 // retry is floor rounded in seconds by redis-cell
                 res.set('Retry-After', retry + 2);
             }

--- a/lib/api/middlewares/rate-limit.js
+++ b/lib/api/middlewares/rate-limit.js
@@ -31,9 +31,13 @@ function rateLimit (userLimits, endpointGroup = null) {
                 'Carto-Rate-Limit-Remaining': remaining,
                 'Carto-Rate-Limit-Reset': reset
             });
+            
+            if (remaining == 0 && !isBlocked) {
+                // retry is floor rounded in seconds by redis-cell
+                res.set('Retry-After', retry + 2);
+            }
 
             if (isBlocked) {
-                // retry is floor rounded in seconds by redis-cell
                 res.set('Retry-After', retry + 1);
 
                 const rateLimitError = new Error(

--- a/test/acceptance/rate-limit-test.js
+++ b/test/acceptance/rate-limit-test.js
@@ -96,7 +96,7 @@ describe('rate limit', function () {
 
     it('1 req/sec: 2 req/seg should be limited', function (done) {
         assertRequest(200, '2', '1', '1');
-        setTimeout(() => assertRequest(200, '2', '0', '1', null), 250);
+        setTimeout(() => assertRequest(200, '2', '0', '1', '1'), 250);
         setTimeout(() => assertRequest(429, '2', '0', '1', '1'), 500);
         setTimeout(() => assertRequest(429, '2', '0', '1', '1'), 750);
         setTimeout(() => assertRequest(429, '2', '0', '1', '1'), 950);


### PR DESCRIPTION
As was reported in #628, is useful return `Retry-after` header when `Carto-Rate-Limit-Remaining` is 0 to avoid force 429 error in order to get seconds remaining until the next permitted call to the API for an user with rate limits enabled.