### PR TITLE
Gdal 2.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules*
 .idea/*
 .vscode/
 test/redis.pid
+test/redis-server.log
 test/test.log
 test/acceptance/oauth/venv/*
 coverage/

--- a/lib/models/formats/ogr.js
+++ b/lib/models/formats/ogr.js
@@ -149,8 +149,9 @@ OgrFormat.prototype.toOGR = function (options, outFormat, outFilename, callback)
 
             var ogrargs = [
                 '-f', outFormat,
-                '-lco', 'RESIZE=YES',
-                '-lco', 'ENCODING=UTF-8',
+                '-lco', 'RESIZE=YES', /* shapefile */
+                '-lco', 'ENCODING=UTF-8', /* shapefile */
+                '-lco', 'STRING_QUOTING=IF_NEEDED', /* csv: Match gdal 2.2 behaviour */
                 '-lco', 'LINEFORMAT=CRLF',
                 outFilename,
                 'PG:host=' + dbhost + ' port=' + dbport + ' user=' + dbuser + ' dbname=' + dbname + ' password=' + dbpass,

--- a/test/acceptance/cache-headers-test.js
+++ b/test/acceptance/cache-headers-test.js
@@ -67,7 +67,7 @@ describe('cache headers', function () {
                 assert.response(server, {
                     url: `/api/v1/sql?${qs.encode({
                         api_key: '1234',
-                        q: `select CDB_TableMetadataTouch('${tableName}'::regclass)`
+                        q: `select cartodb.CDB_TableMetadataTouch('${tableName}'::regclass)`
                     })}`,
                     headers: {
                         host: 'vizzuality.cartodb.com'

--- a/test/acceptance/export/csv-test.js
+++ b/test/acceptance/export/csv-test.js
@@ -210,4 +210,23 @@ describe('export.csv', function () {
             done();
         });
     });
+
+    it('maintains output compatible with gdal 2.2', function (done) {
+        assert.response(server, {
+            url: '/api/v1/sql?' + querystring.stringify({
+                q: 'SELECT cartodb_id, natscale, adm0cap from populated_places_simple_reduced limit 1',
+                format: 'csv'
+            }),
+            headers: { host: 'vizzuality.cartodb.com' },
+            method: 'GET'
+        },
+        {
+            status: 200
+        },
+        function (err, res) {
+            assert.ifError(err);
+            assert.strictEqual(res.body.split('\r\n')[1], '1109,20,0');
+            done();
+        });
+    });
 });

--- a/test/acceptance/surrogate-key-test.js
+++ b/test/acceptance/surrogate-key-test.js
@@ -92,7 +92,7 @@ describe('Surrogate-Key header', function () {
     });
 
     it('should not add header for CDB_QueryTables', function (done) {
-        var sql = "SELECT CDB_QueryTablesText('select * from untitle_table_4')";
+        var sql = "SELECT cartodb.CDB_QueryTablesText('select * from untitle_table_4')";
         assert.response(server, createGetRequest(sql), RESPONSE_OK, function (err, res) {
             assert.ifError(err);
             assert.ok(!Object.prototype.hasOwnProperty.call(res, 'surrogate-key'), res.headers['surrogate-key']);

--- a/test/acceptance/x-cache-channel-test.js
+++ b/test/acceptance/x-cache-channel-test.js
@@ -93,7 +93,7 @@ describe('X-Cache-Channel header', function () {
     });
 
     it('should not add header for CDB_QueryTables', function (done) {
-        var sql = "SELECT CDB_QueryTablesText('select * from untitle_table_4')";
+        var sql = "SELECT cartodb.CDB_QueryTablesText('select * from untitle_table_4')";
         assert.response(server, createGetRequest(sql), RESPONSE_OK, function (err, res) {
             assert.ifError(err);
             assert.ok(!Object.prototype.hasOwnProperty.call(res.headers, 'x-cache-channel'), res.headers['x-cache-channel']);


### PR DESCRIPTION
* A couple of commits of cleaning up.

* Add `STRING_QUOTING=IF_NEEDED` to ogr2ogr so we keep the quoting behaviour of gdal before 2.3. We could switch to `ALWAYS` to be fully consistent but I think we need to make that a conscious decision. 
