### PR TITLE
Disable streaming mode by redis field "streaming_mode"

### DIFF
--- a/lib/api/middlewares/formatter.js
+++ b/lib/api/middlewares/formatter.js
@@ -4,10 +4,20 @@ const formats = require('../../models/formats');
 
 module.exports = function formatter () {
     return function formatterMiddleware (req, res, next) {
-        const { format } = res.locals.params;
+        const { params: { format },  userDbParams: { streamingmode } } = res.locals;
+
+        /* parses streamingmode to boolean. This is:
+          streamingmode = undefined --> true
+          streamingmode = null      --> true
+          streamingmode = 'true'    --> true
+          streamingmode = true      --> true
+          streamingmode = 'false'   --> false
+          streamingmode = false     --> false
+        */
+        const streamingmodeBool = streamingmode !== 'false' && streamingmode !== false;
 
         const FormatClass = formats[format];
-        req.formatter = new FormatClass();
+        req.formatter = new FormatClass(streamingmodeBool);
 
         next();
     };

--- a/lib/models/formats/pg/geojson.js
+++ b/lib/models/formats/pg/geojson.js
@@ -5,7 +5,8 @@ var _ = require('underscore');
 var Pg = require('./../pg');
 const errorHandlerFactory = require('../../../services/error-handler-factory');
 
-function GeoJsonFormat () {
+function GeoJsonFormat (streamingMode = true) {
+    this.streamingMode = streamingMode;
     this.buffer = '';
 }
 
@@ -49,14 +50,14 @@ GeoJsonFormat.prototype.handleQueryRow = function (row) {
 
     this.buffer += (this.total_rows++ ? ',' : '') + geojson.join('');
 
-    if (this.total_rows % (this.opts.bufferedRows || 1000)) {
+    if (this.streamingMode && (this.total_rows % (this.opts.bufferedRows || 1000))) {
         this.opts.sink.write(this.buffer);
         this.buffer = '';
     }
 };
 
 GeoJsonFormat.prototype.handleQueryEnd = function (/* result */) {
-    if (this.error && !this._streamingStarted) {
+    if (this.error && (!this.streamingMode || !this._streamingStarted)) {
         this.callback(this.error);
         return;
     }

--- a/lib/models/formats/pg/json.js
+++ b/lib/models/formats/pg/json.js
@@ -5,7 +5,8 @@ var _ = require('underscore');
 var Pg = require('./../pg');
 const errorHandlerFactory = require('../../../services/error-handler-factory');
 
-function JsonFormat () {
+function JsonFormat (streamingMode = true) {
+    this.streamingMode = streamingMode;
     this.buffer = '';
     this.lastKnownResult = {};
 }
@@ -86,14 +87,14 @@ JsonFormat.prototype.handleQueryRow = function (row, result) {
         return value;
     });
 
-    if (this.total_rows % (this.opts.bufferedRows || 1000)) {
+    if (this.streamingMode && (this.total_rows % (this.opts.bufferedRows || 1000))) {
         this.opts.sink.write(this.buffer);
         this.buffer = '';
     }
 };
 
 JsonFormat.prototype.handleQueryEnd = function (result) {
-    if (this.error && !this._streamingStarted) {
+    if (this.error && (!this.streamingMode || !this._streamingStarted)) {
         this.callback(this.error);
         return;
     }

--- a/lib/models/formats/pg/svg.js
+++ b/lib/models/formats/pg/svg.js
@@ -15,13 +15,14 @@ var fillOpacity = 0.5; // 0.0 is fully transparent, 1.0 is fully opaque
 // unused if fillColor='none'
 var fillColor = 'none'; // affects polygons and circles
 
-function SvgFormat () {
+function SvgFormat (streamingMode = true) {
     this.totalRows = 0;
 
     this.bbox = null; // will be computed during the results scan
     this.buffer = '';
 
     this._streamingStarted = false;
+    this.streamingMode = streamingMode;
 }
 
 SvgFormat.prototype = new Pg('svg');
@@ -82,7 +83,11 @@ SvgFormat.prototype.startStreaming = function () {
 
     header.push(rootTag);
 
-    this.opts.sink.write(header.join('\n'));
+    if (this.streamingMode) {
+        this.opts.sink.write(header.join('\n'));
+    } else {
+        this.buffer = header.join('\n');
+    }
 
     this._streamingStarted = true;
 };
@@ -131,14 +136,14 @@ SvgFormat.prototype.handleQueryRow = function (row) {
         this.startStreaming();
     }
 
-    if (this._streamingStarted && (this.totalRows % (this.opts.bufferedRows || 1000))) {
+    if (this._streamingStarted && this.streamingMode && (this.totalRows % (this.opts.bufferedRows || 1000))) {
         this.opts.sink.write(this.buffer);
         this.buffer = '';
     }
 };
 
 SvgFormat.prototype.handleQueryEnd = function () {
-    if (this.error && !this._streamingStarted) {
+    if (this.error && (!this.streamingMode || !this._streamingStarted)) {
         this.callback(this.error);
         return;
     }

--- a/lib/services/user-database-service.js
+++ b/lib/services/user-database-service.js
@@ -41,7 +41,8 @@ UserDatabaseService.prototype.getConnectionParams = function (username, apikeyTo
         const commonDBConfiguration = {
             port: global.settings.db_port,
             host: dbParams.dbhost,
-            dbname: dbParams.dbname
+            dbname: dbParams.dbname,
+            streamingmode: dbParams.streamingmode
         };
 
         this.metadataBackend.getMasterApikey(username, (err, masterApikey) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -994,9 +994,8 @@
       }
     },
     "cartodb-redis": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cartodb-redis/-/cartodb-redis-3.0.0.tgz",
-      "integrity": "sha512-LVEfvGuBrMOmcDFNYRA0oKK+X9+bCrXW9ge2qtxjkli9TG/fCBI2KDxcgwSCdbACPjtQNKGf8C0lsgzYFSZvOQ==",
+      "version": "github:cartodb/node-cartodb-redis#b12ba897f37ef831e5ea531a3d97518ae7faea0f",
+      "from": "github:cartodb/node-cartodb-redis#feature/ch106733/turn-sql-api-transactional-and-improve-the",
       "requires": {
         "dot": "~1.0.2",
         "redis-mpool": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "bunyan": "1.8.1",
     "cartodb-psql": "0.14.0",
     "cartodb-query-tables": "^0.7.0",
-    "cartodb-redis": "^3.0.0",
+    "cartodb-redis": "github:cartodb/node-cartodb-redis#feature/ch106733/turn-sql-api-transactional-and-improve-the",
     "debug": "^4.1.1",
     "express": "^4.16.4",
     "gc-stats": "^1.4.0",


### PR DESCRIPTION
:warning: This [PR](https://github.com/CartoDB/node-cartodb-redis/pull/34) has to be merged and deployed before merging this.

### Changes

Reading the field `streaming_mode` from db parameters of redis which indicates the operation mode for the SQL API. If `true` (default) then the SQL API streams the results (default behaviour). If this field is set to `false` the the SQL API will return all the results at once.

More info in CH: https://app.clubhouse.io/cartoteam/story/106733/turn-sql-api-transactional-and-improve-the-error-handling