### PR TITLE
Fix row_too_large error handling

### DIFF
--- a/lib/models/formats/pg.js
+++ b/lib/models/formats/pg.js
@@ -138,7 +138,7 @@ PostgresFormat.prototype.sendResponse = function (opts, callback) {
         query.on('error', function (err) {
             that.error = err;
             if (err.message && err.message.match(/row too large, was \d* bytes/i)) {
-                return console.error(JSON.stringify({
+                console.error(JSON.stringify({
                     username: opts.username,
                     type: 'row_size_limit_exceeded',
                     error: err.message


### PR DESCRIPTION
The `return console.error` was preventing the stream to be correctly closed through `handleQueryEnd`

Removing the `return` fixes the weird behaviour and now the errors are consistent