### PR TITLE
[ch140184] Update documentation about fallback templates

### DIFF
--- a/docs/guides/03-batch-queries.md
+++ b/docs/guides/03-batch-queries.md
@@ -460,14 +460,12 @@ This is helpful when you want to save error messages into a table:
 curl -X POST -H "Content-Type: application/json" -d '{
   "query": {
     "query": [{
-      "query": "UPDATE wrong_table SET price = '$100.00' WHERE company = 'CARTO'"
-    }],
-    "onerror": "INSERT INTO errors_log (job_id, error_message, date) VALUES ('<%= job_id %>', '<%= error_message %>', NOW())"
+      "query": "UPDATE wrong_table SET price = '$100.00' WHERE company = 'CARTO'",
+      "onerror": "INSERT INTO errors_log (job_id, error_message, date) VALUES ('<%= job_id %>', '<%= error_message %>', NOW())"
+    }]
   }
 }' "https://{username}.carto.com/api/v2/sql/job"
 ```
-
-More templates are coming soon.
 
 ### Fetching Job Results
 

--- a/docs/guides/03-batch-queries.md
+++ b/docs/guides/03-batch-queries.md
@@ -449,7 +449,7 @@ If a query of a job fails (and onerror fallbacks for that query and job are defi
 
 #### Templates
 
-Batch Queries provide a simple way to get the error message and the job identifier to be used in your fallbacks, by using the following templates:
+Batch Queries provide a simple way to get the error message and the job identifier to be used in your fallbacks defined at the query level, by using the following templates:
 
  - `<%= error_message %>`: will be replaced by the error message raised by the database.
  - `<%= job_id %>`: will be replaced by the job identifier that Batch Queries provides.


### PR DESCRIPTION
### Resources

- [Clubhouse story](https://app.clubhouse.io/cartoteam/story/140184/gloval-seven-admin-batch-query-fallback-templates-not-being-replaced)

### Context

- Fallback templates were implemented only at the query level [here](https://github.com/CartoDB/CartoDB-SQL-API/blob/master/lib/batch/models/query/fallback.js#L30-L59). Fallbacks are also implemented at the job level [here](https://github.com/CartoDB/CartoDB-SQL-API/blob/master/lib/batch/models/query/main-fallback.js#L31-L49), but without any template. 
- However, the example in the documentation is using the fallback template at the job level, storing the information about the error when the table name in the query is invalid, and this can only be performed at the query level (even if there were templates also for the job, because the `error_message` is not propagated).

### Changes

- Updating the documentation, by using the fallback templates at the query level.
- Removing the message about new templates, since I guess that is not true at this point :eyes:.