### PR TITLE
[ch139802] Avoid concurrent requests from getting stuck when exporting file formats handled by OGR - v2

### DIFF
--- a/lib/models/formats/ogr/shp.js
+++ b/lib/models/formats/ogr/shp.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var uuid = require('uuid');
 var step = require('step');
 var fs = require('fs');
 var spawn = require('child_process').spawn;
@@ -37,7 +38,7 @@ ShpFormat.prototype.toSHP = function (options, callback) {
     var zip = global.settings.zipCommand || 'zip';
     var zipOptions = '-qrj';
     var tmpdir = global.settings.tmpDir || '/tmp';
-    var reqKey = this.limitPathname(['shp', dbname, userId, gcol, this.generateMD5(sql)].concat(skipfields).join(':'));
+    var reqKey = this.limitPathname(['shp', dbname, userId, gcol, this.generateMD5(sql), uuid.v4()].concat(skipfields).join(':'));
     var outdirpath = tmpdir + '/sqlapi-' + process.pid + '-' + reqKey;
     var zipfile = outdirpath + '.zip';
     var shapefile = outdirpath + '/' + filename + '.shp';


### PR DESCRIPTION
### Resources

- [Clubhouse story](https://app.clubhouse.io/cartoteam/story/139802/phl-inconsistent-errors-when-downloading-datasets-through-sql-api)
- [Previous PR](https://github.com/CartoDB/CartoDB-SQL-API/pull/680)

### Context

- In the [previous PR](https://github.com/CartoDB/CartoDB-SQL-API/pull/680) it was fixed for all formats managed by OGR, but SHP format was overwriting some part of the code (including the part in which the file name is generated). Since we need a uniq file name (just in case the same request is performed concurrently), it was raising an error saying the file already exists.

### Changes

- Add a random token also to SHP file names.