### PR TITLE
Use a command timeout as a fallback when user's rendering timeout is deactivated

### DIFF
--- a/config/environments/config.js
+++ b/config/environments/config.js
@@ -57,6 +57,7 @@ module.exports.db_pubuser_pass   = 'public';
 module.exports.db_host      = process.env.CARTO_SQL_API_POSTGRES_HOST || 'localhost';
 module.exports.db_port      = process.env.CARTO_SQL_API_POSTGRES_PORT || '6432';
 module.exports.db_batch_port      = process.env.CARTO_SQL_API_POSTGRES_BATCH_PORT || '5432';
+module.exports.export_command_timeout = 5 * 60 * 1000; // 5 minutes in milliseconds
 module.exports.finished_jobs_ttl_in_seconds = 2 * 3600; // 2 hours
 module.exports.batch_query_timeout = 12 * 3600 * 1000; // 12 hours in milliseconds
 module.exports.copy_timeout = "'5h'";

--- a/config/environments/development.js.example
+++ b/config/environments/development.js.example
@@ -52,6 +52,7 @@ module.exports.db_pubuser_pass   = 'public';
 module.exports.db_host      = 'localhost';
 module.exports.db_port      = '5432';
 module.exports.db_batch_port      = '5432';
+module.exports.export_command_timeout = 5 * 60 * 1000; // 5 minutes in milliseconds
 module.exports.finished_jobs_ttl_in_seconds = 2 * 3600; // 2 hours
 module.exports.batch_query_timeout = 12 * 3600 * 1000; // 12 hours in milliseconds
 module.exports.copy_timeout = "'5h'";

--- a/config/environments/production.js.example
+++ b/config/environments/production.js.example
@@ -53,6 +53,7 @@ module.exports.db_pubuser_pass   = 'public';
 module.exports.db_host      = 'localhost';
 module.exports.db_port      = '6432';
 module.exports.db_batch_port      = '5432';
+module.exports.export_command_timeout = 5 * 60 * 1000; // 5 minutes in milliseconds
 module.exports.finished_jobs_ttl_in_seconds = 2 * 3600; // 2 hours
 module.exports.batch_query_timeout = 12 * 3600 * 1000; // 12 hours in milliseconds
 module.exports.copy_timeout = "'5h'";

--- a/config/environments/staging.js.example
+++ b/config/environments/staging.js.example
@@ -53,6 +53,7 @@ module.exports.db_pubuser_pass   = 'public';
 module.exports.db_host      = 'localhost';
 module.exports.db_port      = '6432';
 module.exports.db_batch_port      = '5432';
+module.exports.export_command_timeout = 5 * 60 * 1000; // 5 minutes in milliseconds
 module.exports.finished_jobs_ttl_in_seconds = 2 * 3600; // 2 hours
 module.exports.batch_query_timeout = 12 * 3600 * 1000; // 12 hours in milliseconds
 module.exports.copy_timeout = "'5h'";

--- a/config/environments/test.js.example
+++ b/config/environments/test.js.example
@@ -50,6 +50,7 @@ module.exports.db_pubuser_pass   = 'public';
 module.exports.db_host = process.env.PGHOST || 'localhost';
 module.exports.db_port      = '5432';
 module.exports.db_batch_port      = '5432';
+module.exports.export_command_timeout = 5 * 60 * 1000; // 5 minutes in milliseconds
 module.exports.finished_jobs_ttl_in_seconds = 2 * 3600; // 2 hours
 module.exports.batch_query_timeout = 5 * 1000; // 5 seconds in milliseconds
 module.exports.copy_timeout = "'5h'";

--- a/lib/models/formats/ogr.js
+++ b/lib/models/formats/ogr.js
@@ -58,14 +58,14 @@ OgrFormat.prototype.toOGR = function (options, outFormat, outFilename, callback)
     var dbpass = dbopts.pass;
     var dbname = dbopts.dbname;
 
-    var timeout = 5 * 60 * 1000 // 5 minutes in milliseconds
+    var timeout = 5 * 60 * 1000; // 5 minutes in milliseconds
 
     if (Number.isFinite(global.settings.export_command_timeout)) {
         timeout = global.settings.export_command_timeout;
     }
 
     if (Number.isFinite(options.timeout) && options.timeout > 0) {
-        timeout = options.timeout
+        timeout = options.timeout;
     }
 
     var that = this;

--- a/lib/models/formats/ogr.js
+++ b/lib/models/formats/ogr.js
@@ -58,7 +58,15 @@ OgrFormat.prototype.toOGR = function (options, outFormat, outFilename, callback)
     var dbpass = dbopts.pass;
     var dbname = dbopts.dbname;
 
-    var timeout = options.timeout;
+    var timeout = 5 * 60 * 1000 // 5 minutes in milliseconds
+
+    if (Number.isFinite(global.settings.export_command_timeout)) {
+        timeout = global.settings.export_command_timeout;
+    }
+
+    if (Number.isFinite(options.timeout) && options.timeout > 0) {
+        timeout = options.timeout
+    }
 
     var that = this;
 


### PR DESCRIPTION
**Use a command timeout as a fallback when the user's rendering timeout is deactivated (render timeout === 0)**

CH: [176620](https://app.clubhouse.io/cartoteam/story/176620/servinformacion-is-causing-load-issues-in-sql-api-due-to-huge-export-operations)

In production, many users have the `render timeout` deactivated. This timeout is also used to limit the `ogr2ogr` command time of execution when deactivated users can cause a huge load in the server while exporting. So this PR implements a fallback to prevent long-running exports.