### PR TITLE
[sc189175] Use cursors on PG queries

### DIFF
--- a/lib/api/middlewares/formatter.js
+++ b/lib/api/middlewares/formatter.js
@@ -8,7 +8,6 @@ module.exports = function formatter () {
 
         const FormatClass = formats[format];
         req.formatter = new FormatClass();
-        req.formatter.logger = res.locals.logger;
 
         next();
     };

--- a/lib/api/middlewares/formatter.js
+++ b/lib/api/middlewares/formatter.js
@@ -8,6 +8,7 @@ module.exports = function formatter () {
 
         const FormatClass = formats[format];
         req.formatter = new FormatClass();
+        req.formatter.logger = res.locals.logger;
 
         next();
     };

--- a/lib/api/middlewares/timeout-limits.js
+++ b/lib/api/middlewares/timeout-limits.js
@@ -12,7 +12,8 @@ module.exports = function timeoutLimits (metadataBackend) {
             }
 
             const userLimits = {
-                timeout: (authorizationLevel === 'master') ? timeoutRenderLimit.render : timeoutRenderLimit.renderPublic
+                timeout: (authorizationLevel === 'master') ? timeoutRenderLimit.render : timeoutRenderLimit.renderPublic,
+                export_timeout: timeoutRenderLimit.export
             };
 
             res.locals.userLimits = userLimits;

--- a/lib/api/sql/query-controller.js
+++ b/lib/api/sql/query-controller.js
@@ -93,7 +93,8 @@ function handleQuery ({ stats } = {}) {
                 filename: filename,
                 bufferedRows: global.settings.bufferedRows,
                 callback: callback,
-                timeout: userLimits.timeout
+                timeout: userLimits.timeout,
+                export_timeout: userLimits.export_timeout
             };
 
             if (req.profiler) {

--- a/lib/models/formats/ogr.js
+++ b/lib/models/formats/ogr.js
@@ -64,8 +64,8 @@ OgrFormat.prototype.toOGR = function (options, outFormat, outFilename, callback)
         timeout = global.settings.export_command_timeout;
     }
 
-    if (Number.isFinite(options.timeout) && options.timeout > 0) {
-        timeout = options.timeout;
+    if (Number.isFinite(options.export_timeout) && options.export_timeout > 0) {
+        timeout = options.export_timeout;
     }
 
     var that = this;

--- a/lib/models/formats/pg.js
+++ b/lib/models/formats/pg.js
@@ -136,6 +136,7 @@ PostgresFormat.prototype.sendResponse = function (opts, callback) {
         }
         query.on('end', that.handleQueryEnd.bind(that));
         query.on('error', function (err) {
+            console.log('CUSTOM DEBUG - Error during download: ', err.message);
             that.logger.info({ errorMessage: err.message }, 'Error during download');
             that.error = err;
             if (err.message && err.message.match(/row too large, was \d* bytes/i)) {

--- a/lib/models/formats/pg.js
+++ b/lib/models/formats/pg.js
@@ -126,6 +126,7 @@ PostgresFormat.prototype.sendResponse = function (opts, callback) {
 
     this.client = new PSQL(opts.dbopts);
     this.client.eventedQuery(sql, this.useCursor, function (err, query, queryCanceller) {
+        that.query = query
         that.queryCanceller = queryCanceller;
         if (err) {
             callback(err);
@@ -136,7 +137,6 @@ PostgresFormat.prototype.sendResponse = function (opts, callback) {
         }
 
         query.on('error', function (err) {
-            console.log('CUSTOM DEBUG - Error during download: ', err.message);
             logger.info({ errorMessage: err.message }, 'Error during download');
             that.error = err;
             if (err.message && err.message.match(/row too large, was \d* bytes/i)) {
@@ -147,7 +147,6 @@ PostgresFormat.prototype.sendResponse = function (opts, callback) {
                     error: err.message
                 }));
             }
-
             that.handleQueryEnd();
         });
         query.on('notice', function (msg) {
@@ -166,26 +165,26 @@ PostgresFormat.prototype.sendResponse = function (opts, callback) {
         }
 
         // NOTE: Loop logic using a cursor
-        that.opts.sink.on('drain', function() {
+        that.opts.sink.on('drain', function () {
             // NOTE: This event is triggered when there is room for more rows (output buffer was flushed)
             that.waitingFlush = false;
         });
 
-        var checkBuffer = function() {
+        var checkBuffer = function () {
             that.waitingFlush ? setTimeout(checkBuffer, CHECK_BUFFER_INTERVAL) : readNextRows();
-        }
+        };
 
-        var readNextRows = function() {
-            that.query.read(global.settings.bufferedRows, function(error, rows, result) {
+        var readNextRows = function () {
+            that.query.read(global.settings.bufferedRows, function (_error, rows, result) {
                 that.waitingFlush = false;
 
                 if (rows === undefined) return;
-                if (rows.length == 0) {
+                if (rows.length === 0) {
                     that.handleQueryEnd(result);
                     return;
                 }
 
-                rows.forEach(function(row) {
+                rows.forEach(function (row) {
                     if (that.hasSkipFields) {
                         that.handleQueryRowWithSkipFields(row, result);
                     } else {
@@ -195,7 +194,7 @@ PostgresFormat.prototype.sendResponse = function (opts, callback) {
 
                 checkBuffer();
             });
-        }
+        };
 
         readNextRows();
     });

--- a/lib/models/formats/pg.js
+++ b/lib/models/formats/pg.js
@@ -3,6 +3,9 @@
 var step = require('step');
 var PSQL = require('cartodb-psql');
 
+const serverOptions = require('../../server-options');
+const { logger } = serverOptions();
+
 function PostgresFormat (id) {
     this.id = id;
 }
@@ -137,7 +140,7 @@ PostgresFormat.prototype.sendResponse = function (opts, callback) {
         query.on('end', that.handleQueryEnd.bind(that));
         query.on('error', function (err) {
             console.log('CUSTOM DEBUG - Error during download: ', err.message);
-            that.logger.info({ errorMessage: err.message }, 'Error during download');
+            logger.info({ errorMessage: err.message }, 'Error during download');
             that.error = err;
             if (err.message && err.message.match(/row too large, was \d* bytes/i)) {
                 console.error(JSON.stringify({

--- a/lib/models/formats/pg.js
+++ b/lib/models/formats/pg.js
@@ -136,6 +136,7 @@ PostgresFormat.prototype.sendResponse = function (opts, callback) {
         }
         query.on('end', that.handleQueryEnd.bind(that));
         query.on('error', function (err) {
+            that.logger.info({ errorMessage: err.message }, 'Error during download');
             that.error = err;
             if (err.message && err.message.match(/row too large, was \d* bytes/i)) {
                 console.error(JSON.stringify({

--- a/lib/models/formats/pg.js
+++ b/lib/models/formats/pg.js
@@ -126,7 +126,7 @@ PostgresFormat.prototype.sendResponse = function (opts, callback) {
 
     this.client = new PSQL(opts.dbopts);
     this.client.eventedQuery(sql, this.useCursor, function (err, query, queryCanceller) {
-        that.query = query
+        that.query = query;
         that.queryCanceller = queryCanceller;
         if (err) {
             callback(err);

--- a/lib/models/formats/pg.js
+++ b/lib/models/formats/pg.js
@@ -8,6 +8,7 @@ const { logger } = serverOptions();
 
 function PostgresFormat (id) {
     this.id = id;
+    this.useCursor = false;
 }
 
 PostgresFormat.prototype = {
@@ -119,10 +120,12 @@ PostgresFormat.prototype.sendResponse = function (opts, callback) {
 
     var that = this;
 
+    var CHECK_BUFFER_INTERVAL = 20; // ms
+
     this.start_time = Date.now();
 
     this.client = new PSQL(opts.dbopts);
-    this.client.eventedQuery(sql, function (err, query, queryCanceller) {
+    this.client.eventedQuery(sql, this.useCursor, function (err, query, queryCanceller) {
         that.queryCanceller = queryCanceller;
         if (err) {
             callback(err);
@@ -132,28 +135,69 @@ PostgresFormat.prototype.sendResponse = function (opts, callback) {
             that.opts.profiler.done('eventedQuery');
         }
 
-        if (that.hasSkipFields) {
-            query.on('row', that.handleQueryRowWithSkipFields.bind(that));
-        } else {
-            query.on('row', that.handleQueryRow.bind(that));
-        }
-        query.on('end', that.handleQueryEnd.bind(that));
         query.on('error', function (err) {
             console.log('CUSTOM DEBUG - Error during download: ', err.message);
             logger.info({ errorMessage: err.message }, 'Error during download');
             that.error = err;
             if (err.message && err.message.match(/row too large, was \d* bytes/i)) {
+                that.maxRowSizeError = true;
                 console.error(JSON.stringify({
                     username: opts.username,
                     type: 'row_size_limit_exceeded',
                     error: err.message
                 }));
             }
+
             that.handleQueryEnd();
         });
         query.on('notice', function (msg) {
             that.handleNotice(msg, query._result);
         });
+
+        // NOTE: Legacy mode
+        if (!that.useCursor) {
+            if (that.hasSkipFields) {
+                query.on('row', that.handleQueryRowWithSkipFields.bind(that));
+            } else {
+                query.on('row', that.handleQueryRow.bind(that));
+            }
+            query.on('end', that.handleQueryEnd.bind(that));
+            return;
+        }
+
+        // NOTE: Loop logic using a cursor
+        that.opts.sink.on('drain', function() {
+            // NOTE: This event is triggered when there is room for more rows (output buffer was flushed)
+            that.waitingFlush = false;
+        });
+
+        var checkBuffer = function() {
+            that.waitingFlush ? setTimeout(checkBuffer, CHECK_BUFFER_INTERVAL) : readNextRows();
+        }
+
+        var readNextRows = function() {
+            that.query.read(global.settings.bufferedRows, function(error, rows, result) {
+                that.waitingFlush = false;
+
+                if (rows === undefined) return;
+                if (rows.length == 0) {
+                    that.handleQueryEnd(result);
+                    return;
+                }
+
+                rows.forEach(function(row) {
+                    if (that.hasSkipFields) {
+                        that.handleQueryRowWithSkipFields(row, result);
+                    } else {
+                        that.handleQueryRow(row, result);
+                    }
+                });
+
+                checkBuffer();
+            });
+        }
+
+        readNextRows();
     });
 };
 

--- a/lib/models/formats/pg/geojson.js
+++ b/lib/models/formats/pg/geojson.js
@@ -7,6 +7,7 @@ const errorHandlerFactory = require('../../../services/error-handler-factory');
 
 function GeoJsonFormat () {
     this.buffer = '';
+    this.useCursor = true;
 }
 
 GeoJsonFormat.prototype = new Pg('geojson');
@@ -50,13 +51,13 @@ GeoJsonFormat.prototype.handleQueryRow = function (row) {
     this.buffer += (this.total_rows++ ? ',' : '') + geojson.join('');
 
     if (this.total_rows % (this.opts.bufferedRows || 1000)) {
-        this.opts.sink.write(this.buffer);
+        this.waitingFlush = !this.opts.sink.write(this.buffer);
         this.buffer = '';
     }
 };
 
 GeoJsonFormat.prototype.handleQueryEnd = function (/* result */) {
-    if (this.error && !this._streamingStarted) {
+    if (this.error && !this.maxRowSizeError && !this._streamingStarted) {
         this.callback(this.error);
         return;
     }

--- a/lib/models/formats/pg/json.js
+++ b/lib/models/formats/pg/json.js
@@ -99,8 +99,7 @@ JsonFormat.prototype.handleQueryRow = function (row, result) {
 };
 
 JsonFormat.prototype.handleQueryEnd = function (result) {
-    logger.info({ streamStarted: this._streamingStarted, isError: this.error != undefined }, 'On handleQueryEnd');
-    console.log('CUSTOM DEBUG - handleQueryEnd:', this.error, this._streamingStarted);
+    logger.info({ streamStarted: this._streamingStarted, isError: this.error !== undefined }, 'On handleQueryEnd');
     if (this.error && !this.maxRowSizeError && !this._streamingStarted) {
         this.callback(this.error);
         return;

--- a/lib/models/formats/pg/json.js
+++ b/lib/models/formats/pg/json.js
@@ -11,6 +11,7 @@ const errorHandlerFactory = require('../../../services/error-handler-factory');
 function JsonFormat () {
     this.buffer = '';
     this.lastKnownResult = {};
+    this.useCursor = true;
 }
 
 JsonFormat.prototype = new Pg('json');
@@ -92,7 +93,7 @@ JsonFormat.prototype.handleQueryRow = function (row, result) {
     });
 
     if (this.total_rows % (this.opts.bufferedRows || 1000)) {
-        this.opts.sink.write(this.buffer);
+        this.waitingFlush = !this.opts.sink.write(this.buffer);
         this.buffer = '';
     }
 };
@@ -100,7 +101,7 @@ JsonFormat.prototype.handleQueryRow = function (row, result) {
 JsonFormat.prototype.handleQueryEnd = function (result) {
     logger.info({ streamStarted: this._streamingStarted, isError: this.error != undefined }, 'On handleQueryEnd');
     console.log('CUSTOM DEBUG - handleQueryEnd:', this.error, this._streamingStarted);
-    if (this.error && !this._streamingStarted) {
+    if (this.error && !this.maxRowSizeError && !this._streamingStarted) {
         this.callback(this.error);
         return;
     }
@@ -137,7 +138,7 @@ JsonFormat.prototype.handleQueryEnd = function (result) {
         '],', // end of "rows" array
         '"time":', JSON.stringify(totalTime),
         ',"fields":', JSON.stringify(this.formatResultFields(result.fields)),
-        ',"total_rows":', JSON.stringify(result.rowCount || this.total_rows)
+        ',"total_rows":', JSON.stringify(this.total_rows)
     ];
 
     if (this.error) {

--- a/lib/models/formats/pg/json.js
+++ b/lib/models/formats/pg/json.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const serverOptions = require('../../../server-options');
+const { logger } = serverOptions();
+
 var _ = require('underscore');
 
 var Pg = require('./../pg');
@@ -62,7 +65,7 @@ JsonFormat.prototype.startStreaming = function () {
     this.buffer += '{"rows":[';
     this._streamingStarted = true;
 
-    this.logger.info({ exportTimeout: this.opts.export_timeout }, 'Starting streaming');
+    logger.info({ exportTimeout: this.opts.export_timeout }, 'Starting streaming');
 };
 
 JsonFormat.prototype.handleQueryRow = function (row, result) {
@@ -95,6 +98,7 @@ JsonFormat.prototype.handleQueryRow = function (row, result) {
 };
 
 JsonFormat.prototype.handleQueryEnd = function (result) {
+    logger.info({ streamStarted: this._streamingStarted, isError: this.error != undefined }, 'On handleQueryEnd');
     console.log('CUSTOM DEBUG - handleQueryEnd:', this.error, this._streamingStarted);
     if (this.error && !this._streamingStarted) {
         this.callback(this.error);
@@ -110,7 +114,7 @@ JsonFormat.prototype.handleQueryEnd = function (result) {
     }
 
     this.opts.total_time = (Date.now() - this.start_time) / 1000;
-    this.logger.info({ downloadTime: this.opts.total_time }, 'Download finished');
+    logger.info({ downloadTime: this.opts.total_time }, 'Download finished');
 
     result = result || this.lastKnownResult || {};
 
@@ -167,6 +171,7 @@ JsonFormat.prototype.handleQueryEnd = function (result) {
         this.buffer += ')';
     }
 
+    logger.info({}, 'Closing streaming');
     console.log('CUSTOM DEBUG - Closing streaming');
     this.opts.sink.write(this.buffer);
     this.opts.sink.end();

--- a/lib/models/formats/pg/json.js
+++ b/lib/models/formats/pg/json.js
@@ -61,6 +61,8 @@ JsonFormat.prototype.startStreaming = function () {
     }
     this.buffer += '{"rows":[';
     this._streamingStarted = true;
+
+    this.logger.info({ exportTimeout: this.opts.export_timeout }, 'Starting streaming');
 };
 
 JsonFormat.prototype.handleQueryRow = function (row, result) {
@@ -107,6 +109,7 @@ JsonFormat.prototype.handleQueryEnd = function (result) {
     }
 
     this.opts.total_time = (Date.now() - this.start_time) / 1000;
+    this.logger.info({ downloadTime: this.opts.total_time }, 'Download finished');
 
     result = result || this.lastKnownResult || {};
 

--- a/lib/models/formats/pg/json.js
+++ b/lib/models/formats/pg/json.js
@@ -172,7 +172,6 @@ JsonFormat.prototype.handleQueryEnd = function (result) {
     }
 
     logger.info({}, 'Closing streaming');
-    console.log('CUSTOM DEBUG - Closing streaming');
     this.opts.sink.write(this.buffer);
     this.opts.sink.end();
     this.buffer = '';

--- a/lib/models/formats/pg/json.js
+++ b/lib/models/formats/pg/json.js
@@ -95,6 +95,7 @@ JsonFormat.prototype.handleQueryRow = function (row, result) {
 };
 
 JsonFormat.prototype.handleQueryEnd = function (result) {
+    console.log('CUSTOM DEBUG - handleQueryEnd:', this.error, this._streamingStarted);
     if (this.error && !this._streamingStarted) {
         this.callback(this.error);
         return;
@@ -166,6 +167,7 @@ JsonFormat.prototype.handleQueryEnd = function (result) {
         this.buffer += ')';
     }
 
+    console.log('CUSTOM DEBUG - Closing streaming');
     this.opts.sink.write(this.buffer);
     this.opts.sink.end();
     this.buffer = '';

--- a/lib/models/formats/pg/svg.js
+++ b/lib/models/formats/pg/svg.js
@@ -20,6 +20,7 @@ function SvgFormat () {
 
     this.bbox = null; // will be computed during the results scan
     this.buffer = '';
+    this.useCursor = true;
 
     this._streamingStarted = false;
 }
@@ -132,13 +133,13 @@ SvgFormat.prototype.handleQueryRow = function (row) {
     }
 
     if (this._streamingStarted && (this.totalRows % (this.opts.bufferedRows || 1000))) {
-        this.opts.sink.write(this.buffer);
+        this.waitingFlush = !this.opts.sink.write(this.buffer);
         this.buffer = '';
     }
 };
 
 SvgFormat.prototype.handleQueryEnd = function () {
-    if (this.error && !this._streamingStarted) {
+    if (this.error && !this.maxRowSizeError && !this._streamingStarted) {
         this.callback(this.error);
         return;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1185,7 +1185,7 @@
         },
         "pg": {
           "version": "https://gitpkg.now.sh/CartoDB/node-postgres/packages/pg?cdb-8.7.1-development",
-          "integrity": "sha512-UBFtk4WlwNq4E6O8UnmHSp/4/szQIAWfCrruOdohkX0OGPSMUYzC9HEN6MLu/5AuN4rjwSdKZa9jafaBxO/ldA==",
+          "integrity": "sha512-zdSCmKPxiCfkgZtmd/129OUsPM8Y6cY/I8VSOmveSJ6Do03E0OfM7sRGBhxwwBRBqeTsh4fOiFSK78YIU0X4Ww==",
           "requires": {
             "buffer-writer": "2.0.0",
             "packet-reader": "1.0.0",
@@ -5646,7 +5646,7 @@
     },
     "pg-cursor": {
       "version": "https://gitpkg.now.sh/CartoDB/node-postgres/packages/pg-cursor?cdb-8.7.1-development",
-      "integrity": "sha512-5w5vuqEfk+baVKE36D/Yc3nPj5NhJ75tl9ypHILs3yLhClIwKxZxBUKWezgkphAr9v9N0YfGnfV0NicwHrnToA=="
+      "integrity": "sha512-E2i9WUSKBidghXDlHkB1oDyPE7pyf0x9TJ8IdBBECFTKINBan2u3mtZi5NwmqzQnRJTT/1pZRlm8k/miN1dcdg=="
     },
     "pg-int8": {
       "version": "1.0.1",
@@ -5673,7 +5673,7 @@
     },
     "pg-protocol": {
       "version": "https://gitpkg.now.sh/CartoDB/node-postgres/packages/pg-protocol?cdb-8.7.1-development",
-      "integrity": "sha512-b4Qp9Nf1DWEpJ7PcUuv9ZkHruRYm3PfKPNLRdx2SC9W2xLb4mP2MHDcA6x7SIQFwffLjJ5NW2ESNipGEYyxaaQ=="
+      "integrity": "sha512-o0B1Syl4/JFDouHOBTqQE+quNxl/Irr8uaikkngupoXa8PDf7Ac+oZL85IyBkymnU8gEy/h2AU4ysHUjqcDYUQ=="
     },
     "pg-types": {
       "version": "1.13.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1185,7 +1185,7 @@
         },
         "pg": {
           "version": "https://gitpkg.now.sh/CartoDB/node-postgres/packages/pg?cdb-8.7.1-development",
-          "integrity": "sha512-zdSCmKPxiCfkgZtmd/129OUsPM8Y6cY/I8VSOmveSJ6Do03E0OfM7sRGBhxwwBRBqeTsh4fOiFSK78YIU0X4Ww==",
+          "integrity": "sha512-3cZhg9NuPDBmFIsyrf+0CNNU7F5k879L5eXOj1JEz9ma2HdmeDRYJBySTfkgvxobBJKn0Vj+l3zJTASXM4WF0w==",
           "requires": {
             "buffer-writer": "2.0.0",
             "packet-reader": "1.0.0",
@@ -5646,7 +5646,7 @@
     },
     "pg-cursor": {
       "version": "https://gitpkg.now.sh/CartoDB/node-postgres/packages/pg-cursor?cdb-8.7.1-development",
-      "integrity": "sha512-E2i9WUSKBidghXDlHkB1oDyPE7pyf0x9TJ8IdBBECFTKINBan2u3mtZi5NwmqzQnRJTT/1pZRlm8k/miN1dcdg=="
+      "integrity": "sha512-7mSFkINFf8BHXRDuGrLrYo0xov5vz0s2bHE4qqqHkzA93az4zruTGLA0wPSlSjCXvCrKfCezxNEFA1F1HAIn5w=="
     },
     "pg-int8": {
       "version": "1.0.1",
@@ -5673,7 +5673,7 @@
     },
     "pg-protocol": {
       "version": "https://gitpkg.now.sh/CartoDB/node-postgres/packages/pg-protocol?cdb-8.7.1-development",
-      "integrity": "sha512-o0B1Syl4/JFDouHOBTqQE+quNxl/Irr8uaikkngupoXa8PDf7Ac+oZL85IyBkymnU8gEy/h2AU4ysHUjqcDYUQ=="
+      "integrity": "sha512-zhgrDdGqVXc2tjxoazspNuunjIN5mqFk+2yHtvl42MnZd6qC+c4t8VMJo5PBxoCORUhrLZpwvaCcyCsCEXcRZA=="
     },
     "pg-types": {
       "version": "1.13.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1183,9 +1183,9 @@
       }
     },
     "cartodb-redis": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cartodb-redis/-/cartodb-redis-3.0.0.tgz",
-      "integrity": "sha512-LVEfvGuBrMOmcDFNYRA0oKK+X9+bCrXW9ge2qtxjkli9TG/fCBI2KDxcgwSCdbACPjtQNKGf8C0lsgzYFSZvOQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/cartodb-redis/-/cartodb-redis-3.0.1.tgz",
+      "integrity": "sha512-q0S5xBSthnk5YW2/LB8XD47DcwP82WkWWy5rTw7D8L93NxVe/A2MtzbwBrmrRrC1H80K8pDK9X1XxQNVF2q3+Q==",
       "requires": {
         "dot": "~1.0.2",
         "redis-mpool": "^0.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1053,7 +1053,8 @@
     "buffer-writer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz",
-      "integrity": "sha1-Iqk2kB4wKa/NdUfrRIfOtpejvwg="
+      "integrity": "sha1-Iqk2kB4wKa/NdUfrRIfOtpejvwg=",
+      "dev": true
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -1155,22 +1156,72 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "cartodb-psql": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/cartodb-psql/-/cartodb-psql-0.14.0.tgz",
-      "integrity": "sha512-myLV2xo3q9oTT8m8M+c+UTD/ziDN7hrYtZ9yY00KvMnu2NsVeRQsTe8Yxq1GVS8vF9iYfcelwjVEGObPUdLtHw==",
+      "version": "github:cartodb/node-cartodb-psql#95e719cda18ac2112b95be3a91831ce8781217cc",
+      "from": "github:cartodb/node-cartodb-psql#0.14.1-development",
       "requires": {
         "debug": "^3.1.0",
-        "pg": "github:cartodb/node-postgres#6.4.2-cdb2",
+        "pg": "https://gitpkg.now.sh/CartoDB/node-postgres/packages/pg?cdb-8.7.1-development",
+        "pg-cursor": "https://gitpkg.now.sh/CartoDB/node-postgres/packages/pg-cursor?cdb-8.7.1-development",
         "underscore": "~1.6.0"
       },
       "dependencies": {
+        "buffer-writer": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+          "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
+        },
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "requires": {
             "ms": "^2.1.1"
           }
+        },
+        "packet-reader": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+          "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
+        },
+        "pg": {
+          "version": "https://gitpkg.now.sh/CartoDB/node-postgres/packages/pg?cdb-8.7.1-development",
+          "integrity": "sha512-UBFtk4WlwNq4E6O8UnmHSp/4/szQIAWfCrruOdohkX0OGPSMUYzC9HEN6MLu/5AuN4rjwSdKZa9jafaBxO/ldA==",
+          "requires": {
+            "buffer-writer": "2.0.0",
+            "packet-reader": "1.0.0",
+            "pg-connection-string": "^2.5.0",
+            "pg-pool": "^3.4.1",
+            "pg-protocol": "https://gitpkg.now.sh/CartoDB/node-postgres/packages/pg-protocol?cdb-8.7.1-development",
+            "pg-types": "^2.1.0",
+            "pgpass": "1.x"
+          }
+        },
+        "pg-connection-string": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
+          "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
+        },
+        "pg-pool": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.4.1.tgz",
+          "integrity": "sha512-TVHxR/gf3MeJRvchgNHxsYsTCHQ+4wm3VIHSS19z8NC0+gioEhq1okDY1sm/TYbfoP6JLFx01s0ShvZ3puP/iQ=="
+        },
+        "pg-types": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+          "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+          "requires": {
+            "pg-int8": "1.0.1",
+            "postgres-array": "~2.0.0",
+            "postgres-bytea": "~1.0.0",
+            "postgres-date": "~1.0.4",
+            "postgres-interval": "^1.1.0"
+          }
+        },
+        "postgres-array": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+          "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
         }
       }
     },
@@ -3173,7 +3224,8 @@
     "generic-pool": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.4.3.tgz",
-      "integrity": "sha1-eAw29p360FpaBF3Te+etyhGk9v8="
+      "integrity": "sha1-eAw29p360FpaBF3Te+etyhGk9v8=",
+      "dev": true
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -3986,7 +4038,8 @@
     "js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
-      "integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8="
+      "integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=",
+      "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -5508,7 +5561,8 @@
     "packet-reader": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.3.1.tgz",
-      "integrity": "sha1-zWLmCvjX/qinBexP+ZCHHEaHHyc="
+      "integrity": "sha1-zWLmCvjX/qinBexP+ZCHHEaHHyc=",
+      "dev": true
     },
     "parent-module": {
       "version": "1.0.1",
@@ -5568,6 +5622,7 @@
     "pg": {
       "version": "github:cartodb/node-postgres#5417d7b29b7272ca2e71bb396899ab3f177a9ae6",
       "from": "github:cartodb/node-postgres#6.4.2-cdb2",
+      "dev": true,
       "requires": {
         "buffer-writer": "1.0.1",
         "js-string-escape": "1.0.1",
@@ -5582,11 +5637,16 @@
     "pg-connection-string": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
-      "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
+      "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc=",
+      "dev": true
     },
     "pg-copy-streams": {
       "version": "github:cartodb/node-pg-copy-streams#c9157cd1ab40e02455d949439ae8a913c9ee524e",
       "from": "github:cartodb/node-pg-copy-streams#v2.x-carto"
+    },
+    "pg-cursor": {
+      "version": "https://gitpkg.now.sh/CartoDB/node-postgres/packages/pg-cursor?cdb-8.7.1-development",
+      "integrity": "sha512-5w5vuqEfk+baVKE36D/Yc3nPj5NhJ75tl9ypHILs3yLhClIwKxZxBUKWezgkphAr9v9N0YfGnfV0NicwHrnToA=="
     },
     "pg-int8": {
       "version": "1.0.1",
@@ -5597,6 +5657,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-1.8.0.tgz",
       "integrity": "sha1-9+xzgkw3oD8Hb1G/33DjQBR8Tzc=",
+      "dev": true,
       "requires": {
         "generic-pool": "2.4.3",
         "object-assign": "4.1.0"
@@ -5605,14 +5666,20 @@
         "object-assign": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-          "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A="
+          "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
+          "dev": true
         }
       }
+    },
+    "pg-protocol": {
+      "version": "https://gitpkg.now.sh/CartoDB/node-postgres/packages/pg-protocol?cdb-8.7.1-development",
+      "integrity": "sha512-b4Qp9Nf1DWEpJ7PcUuv9ZkHruRYm3PfKPNLRdx2SC9W2xLb4mP2MHDcA6x7SIQFwffLjJ5NW2ESNipGEYyxaaQ=="
     },
     "pg-types": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.13.0.tgz",
       "integrity": "sha512-lfKli0Gkl/+za/+b6lzENajczwZHc7D5kiUCZfgm914jipD2kIOIvEkAhZ8GrW3/TUoP9w8FHjwpPObBye5KQQ==",
+      "dev": true,
       "requires": {
         "pg-int8": "1.0.1",
         "postgres-array": "~1.0.0",
@@ -5773,7 +5840,8 @@
     "postgres-array": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.3.tgz",
-      "integrity": "sha512-5wClXrAP0+78mcsNX3/ithQ5exKvCyK5lr5NEEEeGwwM6NJdQgzIJBVxLvRW+huFpX92F2QnZ5CcokH0VhK2qQ=="
+      "integrity": "sha512-5wClXrAP0+78mcsNX3/ithQ5exKvCyK5lr5NEEEeGwwM6NJdQgzIJBVxLvRW+huFpX92F2QnZ5CcokH0VhK2qQ==",
+      "dev": true
     },
     "postgres-bytea": {
       "version": "1.0.0",
@@ -6221,7 +6289,8 @@
     "semver": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
-      "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
+      "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c=",
+      "dev": true
     },
     "semver-diff": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "bunyan": "1.8.1",
     "cartodb-psql": "0.14.0",
     "cartodb-query-tables": "^0.7.0",
-    "cartodb-redis": "^3.0.0",
+    "cartodb-redis": "^3.0.1",
     "debug": "^4.1.1",
     "express": "^4.16.4",
     "gc-stats": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "basic-auth": "^2.0.0",
     "bintrees": "1.0.1",
     "bunyan": "1.8.1",
-    "cartodb-psql": "0.14.0",
+    "cartodb-psql": "github:cartodb/node-cartodb-psql#0.14.1-development",
     "cartodb-query-tables": "^0.7.0",
     "cartodb-redis": "^3.0.1",
     "debug": "^4.1.1",

--- a/test/support/test-client.js
+++ b/test/support/test-client.js
@@ -113,7 +113,8 @@ TestClient.prototype.setUserRenderTimeoutLimit = function (user, userTimeoutLimi
     const params = [
         userTimeoutLimitsKey,
         'render', userTimeoutLimit,
-        'render_public', userTimeoutLimit
+        'render_public', userTimeoutLimit,
+        'export', userTimeoutLimit
     ];
 
     redisUtils.configureUserMetadata('hmset', params, callback);


### PR DESCRIPTION
### Resources

- [Shortcut story](https://app.shortcut.com/cartoteam/story/189175/sql-api-oom-errors-when-exporting-data)

### Changes

- ~Use `export_timeout` in OGR exports instead of the render timeout.~ -> https://github.com/CartoDB/CartoDB-SQL-API/pull/698
- Update PG formats based on streams (`json`, `geojson`, `svg`) , to use cursors.