### PR TITLE
[sc189175] Add export timeout for OGR exports

### DIFF
--- a/lib/api/middlewares/timeout-limits.js
+++ b/lib/api/middlewares/timeout-limits.js
@@ -12,7 +12,8 @@ module.exports = function timeoutLimits (metadataBackend) {
             }
 
             const userLimits = {
-                timeout: (authorizationLevel === 'master') ? timeoutRenderLimit.render : timeoutRenderLimit.renderPublic
+                timeout: (authorizationLevel === 'master') ? timeoutRenderLimit.render : timeoutRenderLimit.renderPublic,
+                export_timeout: timeoutRenderLimit.export
             };
 
             res.locals.userLimits = userLimits;

--- a/lib/api/sql/query-controller.js
+++ b/lib/api/sql/query-controller.js
@@ -93,7 +93,8 @@ function handleQuery ({ stats } = {}) {
                 filename: filename,
                 bufferedRows: global.settings.bufferedRows,
                 callback: callback,
-                timeout: userLimits.timeout
+                timeout: userLimits.timeout,
+                export_timeout: userLimits.export_timeout
             };
 
             if (req.profiler) {

--- a/lib/models/formats/ogr.js
+++ b/lib/models/formats/ogr.js
@@ -64,8 +64,8 @@ OgrFormat.prototype.toOGR = function (options, outFormat, outFilename, callback)
         timeout = global.settings.export_command_timeout;
     }
 
-    if (Number.isFinite(options.timeout) && options.timeout > 0) {
-        timeout = options.timeout;
+    if (Number.isFinite(options.export_timeout) && options.export_timeout > 0) {
+        timeout = options.export_timeout;
     }
 
     var that = this;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1183,9 +1183,9 @@
       }
     },
     "cartodb-redis": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cartodb-redis/-/cartodb-redis-3.0.0.tgz",
-      "integrity": "sha512-LVEfvGuBrMOmcDFNYRA0oKK+X9+bCrXW9ge2qtxjkli9TG/fCBI2KDxcgwSCdbACPjtQNKGf8C0lsgzYFSZvOQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/cartodb-redis/-/cartodb-redis-3.0.1.tgz",
+      "integrity": "sha512-q0S5xBSthnk5YW2/LB8XD47DcwP82WkWWy5rTw7D8L93NxVe/A2MtzbwBrmrRrC1H80K8pDK9X1XxQNVF2q3+Q==",
       "requires": {
         "dot": "~1.0.2",
         "redis-mpool": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "bunyan": "1.8.1",
     "cartodb-psql": "0.14.0",
     "cartodb-query-tables": "^0.7.0",
-    "cartodb-redis": "^3.0.0",
+    "cartodb-redis": "^3.0.1",
     "debug": "^4.1.1",
     "express": "^4.16.4",
     "gc-stats": "^1.4.0",

--- a/test/support/test-client.js
+++ b/test/support/test-client.js
@@ -113,7 +113,8 @@ TestClient.prototype.setUserRenderTimeoutLimit = function (user, userTimeoutLimi
     const params = [
         userTimeoutLimitsKey,
         'render', userTimeoutLimit,
-        'render_public', userTimeoutLimit
+        'render_public', userTimeoutLimit,
+        'export', userTimeoutLimit
     ];
 
     redisUtils.configureUserMetadata('hmset', params, callback);


### PR DESCRIPTION
### Resources

- [Shortcut story](https://app.shortcut.com/cartoteam/story/189175/sql-api-oom-errors-when-exporting-data)

### Changes

- Use `export_timeout` in OGR exports instead of the render timeout.